### PR TITLE
cqlsh.py: show Scylla version on startup/show version

### DIFF
--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -841,7 +841,7 @@ class TestCqlshOutput(BaseTestCase):
         with testrun_cqlsh(tty=True, env=self.default_env) as c:
             output = c.cmd_and_response('show version;')
             self.assertRegex(output,
-                    r'^\[cqlsh \S+ \| Cassandra \S+ \| CQL spec \S+ \| Native protocol \S+\]$')
+                    r'^\[cqlsh \S+ \| (Cassandra|Scylla) \S+ \| CQL spec \S+ \| Native protocol \S+\]$')
 
             output = c.cmd_and_response('show host;')
             self.assertHasColors(output)


### PR DESCRIPTION
Now we show the scylla version when connecting
with cqlsh to a scylla cluster

```
❯ cqlsh
Connected to  at 127.0.0.1:9042
[cqlsh 6.0.3.dev0+g5c62c72e04.d20221117 | Scylla 5.2.0~dev-0.20221130.8bc0af9e34fa | CQL spec 3.3.1 | Native protocol v4]
Use HELP for help.
cqlsh> SHOW VERSION
[cqlsh 6.0.3.dev0+g5c62c72e04.d20221117 | Scylla 5.2.0~dev-0.20221130.8bc0af9e34fa | CQL spec 3.3.1 | Native protocol v4]
```

Fixes: #9