### PR TITLE
client side describe was calling `describe_keyspaces` wrongly

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -1569,7 +1569,7 @@ class Shell(cmd.Cmd):
                 aggregatename = self.cql_unprotect_name(parsed.get_binding('udaname'))
                 self.describe_aggregate_client(ksname, aggregatename)
             elif what == 'keyspaces':
-                self.describe_keyspaces()
+                self.describe_keyspaces_client()
             elif what == 'keyspace':
                 ksname = self.cql_unprotect_name(parsed.get_binding('ksname', ''))
                 if not ksname:


### PR DESCRIPTION
seem like in 9ccfa7e29d1372262c2980d78fb35e22b85e039a by mistake we were calling `describe_keyspaces` and not `describe_keyspaces_client`

hence casuing the following error:
```
cqlsh> DESCRIBE KEYSPACES
Shell.describe_keyspaces() missing 1 required positional argument: 'rows'
```