### PR TITLE
dist/redhat: add a proper changelog entry

### DIFF
--- a/dist/redhat/scylla-cqlsh.spec
+++ b/dist/redhat/scylla-cqlsh.spec
@@ -43,4 +43,5 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* initial release
+* Wed Sep 14 2022 Israel Fruchter <fruch@scylladb.com>
+- initial release


### PR DESCRIPTION
it's distracting when trying to find build / test errors. 

without this change, rpmbuild complains at see it like:
```
16:44:37  error: bad date in %changelog: initial release
16:44:37  warning: source_date_epoch_from_changelog set but %changelog
is missing
```