### PR TITLE
Remove unneed LC_ALL=en_US.UTF-8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,6 @@ relocate_python3() {
     cat > "$install"<<EOF
 #!/usr/bin/env bash
 [[ -z "\$LD_PRELOAD" ]] || { echo "\$0: not compatible with LD_PRELOAD" >&2; exit 110; }
-export LC_ALL=en_US.UTF-8
 x="\$(readlink -f "\$0")"
 b="\$(basename "\$x")"
 d="\$(dirname "\$x")"


### PR DESCRIPTION
this generate unneeded noise into stderr when
using cqlsh bundled with scylla

this configuration is now removed in scylla-core, and not needed in cqlsh.

Fix: #21