### PR TITLE
Fix RPM based downgrade command on scylla-cqlsh

### DIFF
--- a/dist/redhat/scylla-cqlsh.spec
+++ b/dist/redhat/scylla-cqlsh.spec
@@ -4,6 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        cqlsh is a Python-based command-line client for running CQL commands on a cassandra cluster.
 Group:          Applications/Databases
 Provides:       %{product}-cqlsh
+Obsoletes:      %{product}-tools < 5.2
 
 License:        Apache
 URL:            http://www.scylladb.com/


### PR DESCRIPTION
Since some of the cqlsh files are also part
of older scylla-tools we to make sure it's Obsoletes the older scylla-tools version

```
Command: 'sudo yum downgrade scylla\\* -y'
Exit code: 1
Stdout:
(8/10): scylla-tools-5.2.0~rc2-0.20230228.908a8 347 kB/s | 120 kB     00:00
(9/10): scylla-tools-core-5.2.0~rc2-0.20230228.  21 MB/s |  42 MB     00:01
(10/10): scylla-debuginfo-5.2.0~rc2-0.20230228.  30 MB/s | 252 MB     00:08
--------------------------------------------------------------------------------
Total                                            45 MB/s | 375 MB     00:08
Running transaction check
Transaction check succeeded.
Running transaction test
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'yum clean packages'.
Stderr:
file /opt/scylladb/share/cassandra/pylib/cqlshlib/test/test_cqlsh_completion.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /opt/scylladb/share/cassandra/pylib/cqlshlib/test/test_cqlsh_output.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /opt/scylladb/share/cassandra/pylib/cqlshlib/test/test_keyspace_init.cql from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /opt/scylladb/share/cassandra/pylib/cqlshlib/test/winpty.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /opt/scylladb/share/cassandra/pylib/cqlshlib/tracing.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /opt/scylladb/share/cassandra/pylib/cqlshlib/util.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /opt/scylladb/share/cassandra/pylib/cqlshlib/wcwidth.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /usr/bin/cqlsh from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
file /usr/bin/cqlsh.py from install of scylla-tools-5.2.0~rc2-0.20230228.908a82bea064.noarch conflicts with file from package scylla-cqlsh-5.3.0~dev-0.20230316.5705df77a155.noarch
```