### PR TITLE
setup: do not support python2 and remove six

### DIFF
--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -35,7 +35,6 @@ setup(
     name="scylla-cqlsh",
     install_requires=[
         "scylla-driver >= 3.25.10",
-        "six",
     ],
     ext_modules=get_extensions(),
     license="Apache",

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -44,7 +44,6 @@ setup(
         "Environment :: Console",
         "Topic :: Database :: Front-Ends",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ]
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 scylla-driver==3.25.10
-six==1.16.0
 geomet==0.2.1.post1
 PyYAML==6.0
 click==8.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -26,7 +24,7 @@ classifiers =
 
 [options]
 packages = cqlsh, cqlshlib
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
+python_requires = >=3.6
 
 # Dependencies are in setup.py for GitHub's dependency graph.
 


### PR DESCRIPTION
we have
```
if sys.version_info < (3, 6):
    sys.exit("\ncqlsh requires Python 3.6+\n")
```

in cqlsh.py, so practically, we only support Python 3.6 and up. so drop the support of Python < 3.6 in the metadata. also, "six" package is removed from setup.py and requirements.txt.