### PR TITLE
build: erase uid/gid information from tar archives

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -27,12 +27,17 @@ import os
 import tarfile
 import pathlib
 
+def erase_uid(tarinfo):
+    tarinfo.uid = tarinfo.gid = 0
+    tarinfo.uname = tarinfo.gname = 'root'
+    return tarinfo
+
 RELOC_PREFIX='scylla-cqlsh'
-def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+def reloc_add(self, name, arcname=None):
     if arcname:
-        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname), filter=erase_uid)
     else:
-        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name), filter=erase_uid)
 
 tarfile.TarFile.reloc_add = reloc_add
 
@@ -51,7 +56,7 @@ ar = tarfile.open(output, mode='w|gz')
 # relocatable package format version = 2
 with open('build/.relocatable_package_version', 'w') as f:
     f.write('2\n')
-ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
+ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version', filter=erase_uid)
 
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
 ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')


### PR DESCRIPTION
The default behavior of tar is to record the uid/gid information, and then restore it. This is problematic if the archive is unpacked as root, since it will create files with the uid/gid of the user who created the archive.

If we build under podman, this normally isn't a problem, since podman runs as root. But under docker we run with the same uid as the caller, and of course it's possible to build without a container at all.

The way I encountered it was when I built both with and without podman. The first build, without podman, copied by uid into the archive. The second build extracted the archive, expanding my uid into podman's subuid range. These files can then no longer be deleted by my original user.

The fix is to add a filter that erases all user information from the tar file as they are added.

Note this indicates a dependency problem - these archives should always be created afresh since the build system doesn't track dependencies for real. This problem is not fixed in this patch.