### PR TITLE
Fix cloudconf handling

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -69,6 +69,33 @@ jobs:
           pip install -r ./pylib/requirements.txt
           pytest ./cqlshlib/test
 
+  integration_test_scylla_cloud_bundle:
+    name: Integration Tests (Scylla Cloud Bundle)
+    if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-test')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start Scylla cloud bundle setup with CCM
+        run: |
+          # install python2 is needed for scylla < 5.3, cause it bundle with old cqlsh
+          sudo apt update -y
+          sudo apt install -y python2
+          
+          python3 -m pip install https://github.com/scylladb/scylla-ccm/archive/master.zip
+          
+          ccm create test_sni -i 127.0.1. -n 1 --scylla --version release:5.2
+          ccm start --sni-proxy --sni-port=8443
+
+          export CQL_TEST_BUNDLE_PATH=$(realpath ~/.ccm/test_sni/config_data.yaml)
+          
+          echo "CQL_TEST_BUNDLE_PATH=${CQL_TEST_BUNDLE_PATH}" >> $GITHUB_ENV
+
+      - name: pytest
+        run: |
+          pip install -r ./pylib/requirements.txt
+          pytest ./cqlshlib/test
+
   integration_test_cassandra:
     name: Integration Tests (Cassandra)
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-test')"

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -485,12 +485,13 @@ class Shell(cmd.Cmd):
             }
 
             if cloudconf is None:
-                assert 'scylla' in DRIVER_NAME.lower(), f"{DRIVER_NAME} {DRIVER_VERSION} isn't supported by scylla_cloud"
                 kwargs['contact_points'] = (self.hostname,)
                 kwargs['port'] = self.port
                 kwargs['ssl_options'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
-                kwargs['scylla_cloud'] = cloudconf
                 profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([self.hostname])
+            else:
+                assert 'scylla' in DRIVER_NAME.lower(), f"{DRIVER_NAME} {DRIVER_VERSION} isn't supported by scylla_cloud"
+                kwargs['scylla_cloud'] = cloudconf
 
             self.conn = Cluster(cql_version=cqlver,
                                 auth_provider=self.auth_provider,
@@ -2122,11 +2123,12 @@ class Shell(cmd.Cmd):
 
         kwargs = {}
         if self.cloudconf is None:
-                kwargs['contact_points'] = (self.hostname,)
-                kwargs['port'] = self.port
-                kwargs['ssl_options'] = self.conn.ssl_options
-                kwargs['load_balancing_policy'] = WhiteListRoundRobinPolicy([self.hostname])
-                kwargs['scylla_cloud'] = self.cloudconf
+            kwargs['contact_points'] = (self.hostname,)
+            kwargs['port'] = self.port
+            kwargs['ssl_options'] = self.conn.ssl_options
+            kwargs['load_balancing_policy'] = WhiteListRoundRobinPolicy([self.hostname])
+        else:
+            kwargs['scylla_cloud'] = self.cloudconf
 
         conn = Cluster(cql_version=self.conn.cql_version,
                        protocol_version=self.conn.protocol_version,

--- a/pylib/cqlshlib/test/basecase.py
+++ b/pylib/cqlshlib/test/basecase.py
@@ -33,6 +33,7 @@ path_to_cqlsh = join(cqlsh_dir, 'cqlsh.py')
 sys.path.append(cqlsh_dir)
 
 TEST_HOST = os.environ.get('CQL_TEST_HOST', '127.0.0.1')
+TEST_BUNDLE_PATH = os.environ.get('CQL_TEST_BUNDLE_PATH')
 TEST_PORT = int(os.environ.get('CQL_TEST_PORT', 9042))
 TEST_USER = os.environ.get('CQL_TEST_USER', 'cassandra')
 TEST_PWD = os.environ.get('CQL_TEST_PWD')

--- a/pylib/cqlshlib/test/cassconnect.py
+++ b/pylib/cqlshlib/test/cassconnect.py
@@ -26,7 +26,7 @@ from cassandra.metadata import maybe_escape_name as quote_name
 from cassandra.auth import PlainTextAuthProvider
 from cqlshlib.cql3handling import CqlRuleSet
 
-from .basecase import TEST_HOST, TEST_PORT, TEST_USER, TEST_PWD, cqlshlog, test_dir
+from .basecase import TEST_HOST, TEST_PORT, TEST_USER, TEST_PWD, cqlshlog, test_dir, TEST_BUNDLE_PATH
 from .run_cqlsh import run_cqlsh, call_cqlsh
 
 test_keyspace_init = os.path.join(test_dir, 'test_keyspace_init.cql')
@@ -35,7 +35,10 @@ test_keyspace_init = os.path.join(test_dir, 'test_keyspace_init.cql')
 def get_cassandra_connection(cql_version=None):
 
     auth_provider = PlainTextAuthProvider(username=TEST_USER, password=TEST_PWD)
-    conn = Cluster((TEST_HOST,), TEST_PORT, auth_provider=auth_provider, cql_version=cql_version)
+    if TEST_BUNDLE_PATH:
+        conn = Cluster(scylla_cloud=TEST_BUNDLE_PATH, auth_provider=auth_provider, cql_version=cql_version)
+    else:
+        conn = Cluster((TEST_HOST,), TEST_PORT, auth_provider=auth_provider, cql_version=cql_version)
 
     # until the cql lib does this for us
     conn.cql_version = cql_version

--- a/pylib/cqlshlib/test/run_cqlsh.py
+++ b/pylib/cqlshlib/test/run_cqlsh.py
@@ -244,7 +244,10 @@ class CqlshRunner(ProcRunner):
         coverage = False
         if ('CQLSH_COVERAGE' in env.keys()):
             coverage = True
-        args = tuple(args) + (host, str(port))
+        if basecase.TEST_BUNDLE_PATH:
+            args = tuple(args) + ("--cloudconf", basecase.TEST_BUNDLE_PATH)
+        else:
+            args = tuple(args) + (host, str(port))
         if cqlver is not None:
             args += ('--cqlversion', str(cqlver))
         if keyspace is not None:

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -26,7 +26,7 @@ import pytest
 from cassandra import InvalidRequest
 
 from .basecase import (BaseTestCase, TEST_HOST, TEST_PORT,
-                       at_a_time, cqlshlog, dedent)
+                       at_a_time, cqlshlog, dedent, TEST_BUNDLE_PATH)
 from .cassconnect import (cassandra_cursor, create_db, get_keyspace,
                           quote_name, remove_db, split_cql_commands,
                           testcall_cqlsh, testrun_cqlsh)
@@ -845,8 +845,10 @@ class TestCqlshOutput(BaseTestCase):
 
             output = c.cmd_and_response('show host;')
             self.assertHasColors(output)
-            self.assertRegex(output, '^Connected to .* at %s:%d$'
-                                             % (re.escape(TEST_HOST), TEST_PORT))
+            if TEST_BUNDLE_PATH:
+                self.assertRegex(output, r'Connected to .* at Scylla Cloud\.$')
+            else:
+                self.assertRegex(output, f'^Connected to .* at {re.escape(TEST_HOST)}:{TEST_PORT}$')
 
     def test_eof_prints_newline(self):
         with testrun_cqlsh(tty=True, env=self.default_env) as c:


### PR DESCRIPTION
the change in ad1c8d8e99a03614c8bf136c568fb59b2112bc3f
broke the cloudconf option, since it mixed it with all
the other parameter which are not working together
with the cloud bundle options, and it need to be on
it's own branch of the code.