### PR TITLE
Skip pp39-macosx wheel builds

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  CIBW_SKIP: cp36*
+  CIBW_SKIP: cp36* pp39-macosx*
 
 jobs:
   build_wheels:


### PR DESCRIPTION
seems like those builds are not compiling for us,
temporary disable them until we can figure it out
```
    error: subprocess-exited-with-error

    × Building wheel for scylla-cqlsh (pyproject.toml) did not run successfully.
    │ exit code: 1
    ╰─> [9 lines of output]
        cqlshlib/copyutil.c:85563:29: error: implicit declaration of function 'PyInterpreterState_GetID' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            PY_INT64_T current_id = PyInterpreterState_GetID(PyThreadState_Get()->interp);
                                    ^
        1 error generated.
        /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-t6wotqku/overlay/lib/pypy3.9/site-packages/setuptools_scm/git.py:135: UserWarning: "/Users/runner/work/scylla-cqlsh/scylla-cqlsh" is shallow and may cause errors
          warnings.warn(f'"{wd.path}" is shallow and may cause errors')
        /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-t6wotqku/overlay/lib/pypy3.9/site-packages/setuptools_scm/version.py:91: UserWarning: tag 'v6.0.10-scylla' will be stripped of its suffix '-scylla'

```