### PR TITLE
switch from `ssl_options` to `ssl_context`

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -487,7 +487,7 @@ class Shell(cmd.Cmd):
             if cloudconf is None:
                 kwargs['contact_points'] = (self.hostname,)
                 kwargs['port'] = self.port
-                kwargs['ssl_options'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
+                kwargs['ssl_context'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
                 profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([self.hostname])
             else:
                 assert 'scylla' in DRIVER_NAME.lower(), f"{DRIVER_NAME} {DRIVER_VERSION} isn't supported by scylla_cloud"
@@ -2125,7 +2125,7 @@ class Shell(cmd.Cmd):
         if self.cloudconf is None:
             kwargs['contact_points'] = (self.hostname,)
             kwargs['port'] = self.port
-            kwargs['ssl_options'] = self.conn.ssl_options
+            kwargs['ssl_context'] = self.conn.ssl_context
             kwargs['load_balancing_policy'] = WhiteListRoundRobinPolicy([self.hostname])
         else:
             kwargs['scylla_cloud'] = self.cloudconf

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -1682,7 +1682,7 @@ class ExportProcess(ChildProcess):
             cql_version=self.cql_version,
             protocol_version=self.protocol_version,
             auth_provider=self.auth_provider,
-            ssl_options=ssl_settings(host, self.config_file) if self.ssl else None,
+            ssl_context=ssl_settings(host, self.config_file) if self.ssl else None,
             load_balancing_policy=WhiteListRoundRobinPolicy([host]),
             default_retry_policy=ExpBackoffRetryPolicy(self),
             compression=None,
@@ -2355,7 +2355,7 @@ class ImportProcess(ChildProcess):
                 protocol_version=self.protocol_version,
                 auth_provider=self.auth_provider,
                 load_balancing_policy=FastTokenAwarePolicy(self),
-                ssl_options=ssl_settings(self.hostname, self.config_file) if self.ssl else None,
+                ssl_context=ssl_settings(self.hostname, self.config_file) if self.ssl else None,
                 default_retry_policy=FallthroughRetryPolicy(),  # we throw on timeouts and retry in the error callback
                 compression=None,
                 control_connection_timeout=self.connect_timeout,


### PR DESCRIPTION
This change give us more control when the keys are gonna be loaded, and the passphrses would be asked.

we need to make sure it happen before we start the cqlsh interpeter, and this one the passphrase is being asked from the user only once, and not multiple times on every socket being opened.

Fixes: #46