### PR TITLE
setup.py: explicitly specify cython's language_level

### DIFF
--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -27,7 +27,10 @@ def get_extensions():
 
     try:
         from Cython.Build import cythonize
-        return cythonize(Extension(name='copyutil', sources=["cqlshlib/copyutil.py"], define_macros=[("CYTHON_LIMITED_API", "1")]))
+        extensions = [Extension(name='copyutil',
+                                sources=["cqlshlib/copyutil.py"],
+                                define_macros=[("CYTHON_LIMITED_API", "1")])]
+        return cythonize(extensions)
     except ImportError:
         warnings.warn("installing cython could speed things up for you; `pip install cython`")
 

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -30,7 +30,8 @@ def get_extensions():
         extensions = [Extension(name='copyutil',
                                 sources=["cqlshlib/copyutil.py"],
                                 define_macros=[("CYTHON_LIMITED_API", "1")])]
-        return cythonize(extensions)
+        return cythonize(extensions,
+                         compiler_directives={'language_level': '3str'})
     except ImportError:
         warnings.warn("installing cython could speed things up for you; `pip install cython`")
 

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -22,13 +22,14 @@ from distutils.core import setup, Extension
 
 
 def get_extensions():
-    if "--no-compile" not in sys.argv:
+    if "--no-compile" in sys.argv:
+        return []
+    else:
         try:
             from Cython.Build import cythonize
             return cythonize(Extension(name='copyutil', sources=["cqlshlib/copyutil.py"], define_macros=[("CYTHON_LIMITED_API", "1")]))
         except ImportError:
             warnings.warn("installing cython could speed things up for you; `pip install cython`")
-    return []
 
 
 setup(

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -24,12 +24,12 @@ from distutils.core import setup, Extension
 def get_extensions():
     if "--no-compile" in sys.argv:
         return []
-    else:
-        try:
-            from Cython.Build import cythonize
-            return cythonize(Extension(name='copyutil', sources=["cqlshlib/copyutil.py"], define_macros=[("CYTHON_LIMITED_API", "1")]))
-        except ImportError:
-            warnings.warn("installing cython could speed things up for you; `pip install cython`")
+
+    try:
+        from Cython.Build import cythonize
+        return cythonize(Extension(name='copyutil', sources=["cqlshlib/copyutil.py"], define_macros=[("CYTHON_LIMITED_API", "1")]))
+    except ImportError:
+        warnings.warn("installing cython could speed things up for you; `pip install cython`")
 
 
 setup(


### PR DESCRIPTION
this series restructures `get_extensions()`, and also silences the warning like:

```
/tmp/build-env-p23crgfa/lib64/python3.11/site-packages/Cython/Compiler/Main.py:384: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /home/kefu/dev/scylladb/tools/cqlsh/cqlshlib/copyutil.py
  tree = Parsing.p_module(s, pxd, full_module_name)
```
