### PR TITLE
reloc: install build==0.10.0

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -79,7 +79,7 @@ else
     ZIP_EXTRA_OPTS="--quiet"
 fi
 
-python3 -m pip install ${PIP_EXTRA_OPTS} build==0.8.0 wheel==0.37.1 -t ./build/cqlsh_build
+python3 -m pip install ${PIP_EXTRA_OPTS} build==0.10.0 wheel==0.37.1 -t ./build/cqlsh_build
 PYTHONPATH=$(pwd)/build/cqlsh_build python3 -m build -s
 PYTHONPATH=$(pwd)/build/cqlsh_build python3 -m pip download ${PIP_EXTRA_OPTS} --constraint ./requirements.txt --no-binary :all: . --no-build-isolation -d ./build/pypi_packages
 


### PR DESCRIPTION
to silence the warning from pip:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
poetry 1.5.1 requires build<0.11.0,>=0.10.0, but you have build 1.0.3 which is incompatible.
```

unfortunately, despite that poetry master HEAD now supports build==1.0.3, the latest release of poetry (v1.6.1) still does not include that change. so let's use the version supported by poetry.