### PR TITLE
Draft: explicit build-time package dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim-bullseye AS compile-image
 
 WORKDIR /usr/src/app
-RUN apt-get update && apt-get -y install git gcc
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install --no-install-recommends git gcc libc6-dev
 
 COPY . .
 RUN pip install --user .


### PR DESCRIPTION
Seen @ https://github.com/docker-library/python/blob/7899dbafd386ee264bd33574aafcd0f1369b2e21/3.11/slim-bullseye/Dockerfile#L33 Instead of installing all recommended packages, we explicitly mention what we need. It reduces the download of 10's of build-time dependencies.

What I'm not sure of - are we missing features, that are not compiled as deps are not found? (encryption comes to mind).