### PR TITLE
dist/debian: add trailer line

### DIFF
--- a/dist/debian/changelog.template
+++ b/dist/debian/changelog.template
@@ -1,3 +1,5 @@
 %{product}-cqlsh (%{version}-%{release}-%{revision}) %{codename}; urgency=medium
 
   * New release
+
+ -- Israel Fruchter <fruch@scylladb.com> %{timestamp}

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import string
 import os
 import shutil
@@ -47,11 +48,13 @@ if os.path.exists('build/debian/debian'):
 shutil.copytree('dist/debian/debian', 'build/debian/debian')
 
 s = DebianFilesTemplate(changelog_template)
+now = datetime.datetime.now(tz=datetime.timezone.utc)
 changelog_applied = s.substitute(product=product,
                                  version=version,
                                  release=release,
                                  revision='1',
-                                 codename='stable')
+                                 codename='stable',
+                                 timestamp=now.strftime("%a, %d %b %Y %H:%M:%S %z"))
 
 s = DebianFilesTemplate(control_template)
 control_applied = s.substitute(product=product)

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -47,7 +47,11 @@ if os.path.exists('build/debian/debian'):
 shutil.copytree('dist/debian/debian', 'build/debian/debian')
 
 s = DebianFilesTemplate(changelog_template)
-changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')
+changelog_applied = s.substitute(product=product,
+                                 version=version,
+                                 release=release,
+                                 revision='1',
+                                 codename='stable')
 
 s = DebianFilesTemplate(control_template)
 control_applied = s.substitute(product=product)


### PR DESCRIPTION
this should address the warnings from dpkg-source and
dpkg-parsechangelog, like:

```
dpkg-source: warning: scylla-package/debian/changelog(l3): found end of file where expected more change data or trailer
```

```
dpkg-parsechangelog: warning:     debian/changelog(l3): found end of file where expected more change data or trailer
```