### PR TITLE
Make cqlsh work with unix domain sockets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scylla-driver==3.26.3
+scylla-driver==3.26.5
 geomet==0.2.1.post1
 PyYAML==6.0
 click==8.1.3


### PR DESCRIPTION
In order to use unix domain sockets with python-driver, we have to wrap hostname in UnixSocketEndPoint (like in this example: http://opensource.docs.scylladb.com/master/operating-scylla/admin-tools/maintenance-socket.html#with-python-driver). 

This PR adds checking if hostname is a socket, and if so, it adds wrapping hostname into UnixSocketEndPoint.

I tested it locally using python-driver.

To work correctly it needs 3.26.5 python-driver release (there was no support for unix domain sockets in `WhiteListRoundRobinPolicy` before).

Fixes: https://github.com/scylladb/scylladb/issues/16489