### PR TITLE
dist/debian: fix the trailer line format

### DIFF
--- a/dist/debian/changelog.template
+++ b/dist/debian/changelog.template
@@ -2,4 +2,4 @@
 
   * New release
 
- -- Israel Fruchter <fruch@scylladb.com> %{timestamp}
+ -- Israel Fruchter <fruch@scylladb.com>  %{timestamp}


### PR DESCRIPTION
should add two spaces between maintainer's mail and timestamp.

this should address the warning like
```
22:33:44  dpkg-parsechangelog: warning:     debian/changelog(l5): badly formatted trailer line
22:33:44  LINE:  -- Israel Fruchter <fruch@scylladb.com> Fri, 02 Feb 2024 14:33:31 +0000
```