### PR TITLE
Fix the support for separate credential file

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -2421,7 +2421,7 @@ def read_options(cmdlineargs, environment):
             print("\nWarning: Password is found in an insecure cqlshrc file. The file is owned or readable by other users on the system.",
                   end='', file=sys.stderr)
         print("\nNotice: Credentials in the cqlshrc file is deprecated and will be ignored in the future."
-              "\nPlease use a credentials file to specify the username and password.\n", file=sys.stderr)
+              "\nPlease use a credentials file to specify the username and password.\n")
 
     optvalues = optparse.Values()
 
@@ -2493,7 +2493,7 @@ def read_options(cmdlineargs, environment):
         credentials.read(options.credentials)
 
         # use the username from credentials file but fallback to cqlshrc if username is absent from the command line parameters
-        options.username = username_from_cqlshrc
+        options.username = option_with_default(credentials.get, 'plain_text_auth', 'username', username_from_cqlshrc)
 
     if not options.password:
         rawcredentials = configparser.RawConfigParser()
@@ -2501,7 +2501,6 @@ def read_options(cmdlineargs, environment):
 
         # handling password in the same way as username, priority cli > credentials > cqlshrc
         options.password = option_with_default(rawcredentials.get, 'plain_text_auth', 'password', password_from_cqlshrc)
-        options.password = password_from_cqlshrc
     elif not options.insecure_password_without_warning:
         print("\nWarning: Using a password on the command line interface can be insecure."
               "\nRecommendation: use the credentials file to securely provide the password.\n", file=sys.stderr)

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -2421,7 +2421,8 @@ def read_options(cmdlineargs, environment):
             print("\nWarning: Password is found in an insecure cqlshrc file. The file is owned or readable by other users on the system.",
                   end='', file=sys.stderr)
         print("\nNotice: Credentials in the cqlshrc file is deprecated and will be ignored in the future."
-              "\nPlease use a credentials file to specify the username and password.\n")
+              "\nPlease use a credentials file to specify the username and password.\n"
+              "\nTo use basic authentication, place the username and password in the [PlainTextAuthProvider] section of the credentials file.\n", file=sys.stderr)
 
     optvalues = optparse.Values()
 

--- a/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_legacy
+++ b/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_legacy
@@ -1,0 +1,3 @@
+[plain_text_auth]
+password = pass4
+username = user4

--- a/pylib/cqlshlib/test/test_legacy_auth.py
+++ b/pylib/cqlshlib/test/test_legacy_auth.py
@@ -1,0 +1,55 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+import io
+import os
+import sys
+import pytest
+from unittest.mock import patch
+
+from cassandra.auth import PlainTextAuthProvider
+import cqlshlib.authproviderhandling as auth_prov
+from cqlshlib.test.test_authproviderhandling import construct_config_path, _assert_auth_provider_matches
+
+
+class CustomAuthLegacyTest(unittest.TestCase):
+
+    def setUp(self):
+        self._captured_std_err = io.StringIO()
+        sys.stderr = self._captured_std_err
+        self.fake_is_file_secure = lambda filename: True
+        self.patcher = patch('cqlshlib.util.is_file_secure', self.fake_is_file_secure)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self._captured_std_err.close()
+        sys.stdout = sys.__stderr__
+    
+    def test_legacy_credentials(self):
+        from cqlshlib.util import is_file_secure
+        from bin.cqlsh import read_options as cqlsh_read_options
+        
+        creds_file = construct_config_path('plain_text_legacy')
+        opts, _, _ = cqlsh_read_options(['--credentials='+creds_file], {})
+        actual = auth_prov.load_auth_provider(cred_file=creds_file, username=opts.username, password=opts.password)
+        _assert_auth_provider_matches(
+                actual,
+                PlainTextAuthProvider,
+                {"username": 'user4',
+                "password": 'pass4'})
+


### PR DESCRIPTION
I have restored the ability to specify a login and password in cqlshrc.
However, I discovered that the features introduced by this commit are not reflected in the documentation.
If you tell me how to make changes to the documentation, I can add a description of using AuthProviders for cqlsh to the documentation.
I also see shortcomings in the tests, for example cqlshlib/test/test_cqlsh_completion.py does not work correctly on an empty database. Therefore, the autotests did not pass completely. But this needs to be corrected with a separate pull request.

Fixes: #73