### PR TITLE
set the hostname in ssl_options.server_hostname when SSL is used

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -494,6 +494,8 @@ class Shell(cmd.Cmd):
                     profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([self.hostname])
                 kwargs['port'] = self.port
                 kwargs['ssl_context'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
+                # workaround until driver would know not to lose the DNS names for `server_hostname`
+                kwargs['ssl_options'] = {'server_hostname': self.hostname} if ssl else None
             else:
                 assert 'scylla' in DRIVER_NAME.lower(), f"{DRIVER_NAME} {DRIVER_VERSION} isn't supported by scylla_cloud"
                 kwargs['scylla_cloud'] = cloudconf
@@ -2131,6 +2133,7 @@ class Shell(cmd.Cmd):
             kwargs['contact_points'] = (self.hostname,)
             kwargs['port'] = self.port
             kwargs['ssl_context'] = self.conn.ssl_context
+            kwargs['ssl_options'] = self.conn.ssl_options
             if os.path.exists(self.hostname) and stat.S_ISSOCK(os.stat(self.hostname).st_mode):
                 kwargs['load_balancing_policy'] = WhiteListRoundRobinPolicy([UnixSocketEndPoint(self.hostname)])
             else: 

--- a/pylib/cqlshlib/sslhandling.py
+++ b/pylib/cqlshlib/sslhandling.py
@@ -58,6 +58,11 @@ def ssl_settings(host, config_file, env=os.environ):
         ssl_validate = get_option('ssl', 'validate')
     ssl_validate = ssl_validate is None or ssl_validate.lower() != 'false'
 
+    ssl_check_hostname = env.get('SSL_check_hostname')
+    if ssl_check_hostname is None:
+        ssl_check_hostname = get_option('ssl', 'check_hostname')
+    ssl_check_hostname = ssl_check_hostname is None or ssl_check_hostname.lower() != 'false'
+
     ssl_version_str = env.get('SSL_VERSION')
     if ssl_version_str is None:
         ssl_version_str = get_option('ssl', 'version')
@@ -85,7 +90,7 @@ def ssl_settings(host, config_file, env=os.environ):
         usercert = os.path.expanduser(usercert)
 
     ssl_context = ssl.SSLContext(ssl_version)
-    ssl_context.check_hostname = ssl_validate
+    ssl_context.check_hostname = ssl_check_hostname
     ssl_context.load_cert_chain(certfile=usercert,
                                 keyfile=userkey)
 


### PR DESCRIPTION
since driver assign automatically `server_hostname` only with ip
and don't use DNS name, cqlsh need to pass it along until
that would be addressed

Fix: https://github.com/scylladb/scylla-cqlsh/issues/75