### PR TITLE
cqlshlib/sslhandling.py: don't use empty userkey/usercert

### DIFF
--- a/pylib/cqlshlib/sslhandling.py
+++ b/pylib/cqlshlib/sslhandling.py
@@ -91,8 +91,11 @@ def ssl_settings(host, config_file, env=os.environ):
 
     ssl_context = ssl.SSLContext(ssl_version)
     ssl_context.check_hostname = ssl_check_hostname
-    ssl_context.load_cert_chain(certfile=usercert,
-                                keyfile=userkey)
+    if usercert and userkey:
+        ssl_context.load_cert_chain(certfile=usercert,
+                                    keyfile=userkey)
+    if (usercert and not userkey) or (userkey and not usercert):
+        print("Warning: userkey and usercert from [ssl] section, should be both configured, otherwise won't be used")
 
     ssl_context.verify_mode = ssl.CERT_REQUIRED if ssl_validate else ssl.CERT_NONE
     if ssl_certfile:


### PR DESCRIPTION
when configuration doesn't define `usercert` or `userkey`

we fail as the following:
```bash
Using CQL driver: <module 'cassandra' from '/opt/scylladb/share/cassandra/libexec/../lib/scylla-driver-3.26.3.zip/cassandra/__init__.py'>
Using connect timeout: 5 seconds
Using 'utf-8' encoding
Using ssl: True
Using cloudconf: None
Traceback (most recent call last):
  File "/opt/scylladb/share/cassandra/libexec/cqlsh.py", line 2706, in <module>
    main(*read_options(sys.argv[1:], os.environ))
  File "/opt/scylladb/share/cassandra/libexec/cqlsh.py", line 2647, in main
    shell = Shell(hostname,
            ^^^^^^^^^^^^^^^
  File "/opt/scylladb/share/cassandra/libexec/cqlsh.py", line 490, in __init__
    kwargs['ssl_context'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scylladb/share/cassandra/libexec/../pylib/cqlshlib/sslhandling.py", line 89, in ssl_settings
    ssl_context.load_cert_chain(certfile=usercert,
TypeError: certfile should be a valid filesystem path
```

* we don't call load_cert_chain anymore if any of the params are empty
* and now we warn the user if it's missconfigured (if one is and the other isn't)

Fixes: #83