### PR TITLE
Dockerfile: noninteractive isn't enough for answering yet on apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install --user .
 FROM python:3.11-slim-bullseye AS build-image
 
 # Upgrade packages to the latest, pip as well.
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade --no-cache-dir pip
 
 COPY --from=compile-image /root/.local /root/.local


### PR DESCRIPTION
since a while the docker seem to have been broken like the following:

```
 > [linux/amd64 build-image 2/4] RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*:
2.601 Reading package lists...
3.259 Building dependency tree...
3.410 Reading state information...
3.428 Calculating upgrade...
3.577 The following packages will be upgraded:
3.578   libc-bin libc6
3.581 2 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
3.581 Need to get 3652 kB of archives.
3.581 After this operation, 0 B of additional disk space will be used.
3.581 Do you want to continue? [Y/n] Abort.
------
Dockerfile:13
--------------------
  11 |
  12 |     # Upgrade packages to the latest, pip as well.
  13 | >>> RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
  14 |     RUN pip install --upgrade --no-cache-dir pip
  15 |
--------------------
ERROR: failed to solve: process "/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*"

did not complete successfully: exit code: 1
```

adding a `-y` fixes the issue, and would unblock the pushes to PyPi