### PR TITLE
cqlshlib/sslhandling: fix logic of `ssl_check_hostname`

### DIFF
--- a/pylib/cqlshlib/sslhandling.py
+++ b/pylib/cqlshlib/sslhandling.py
@@ -61,7 +61,7 @@ def ssl_settings(host, config_file, env=os.environ):
     ssl_check_hostname = env.get('SSL_CHECK_HOSTNAME')
     if ssl_check_hostname is None:
         ssl_check_hostname = get_option('ssl', 'check_hostname')
-    ssl_check_hostname = ssl_check_hostname is not None or ssl_check_hostname.lower() != 'false'
+    ssl_check_hostname = ssl_check_hostname is not None and ssl_check_hostname.lower() != 'false'
 
     if ssl_check_hostname and not ssl_validate:
         sys.exit("SSL certificate hostname checking "


### PR DESCRIPTION
the logic was broken, and could lead to `AttributeError`, like the following:
```
E       AssertionError: Traceback (most recent call last):
E           File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.ccm/scylla-repository/18591/share/cassandra/libexec/cqlsh.py", line 2723, in <module>
E             main(*read_options(sys.argv[1:], os.environ))
E           File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.ccm/scylla-repository/18591/share/cassandra/libexec/cqlsh.py", line 2664, in main
E             shell = Shell(hostname,
E                     ^^^^^^^^^^^^^^^
E           File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.ccm/scylla-repository/18591/share/cassandra/libexec/cqlsh.py", line 495, in __init__
E             kwargs['ssl_context'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
E                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.ccm/scylla-repository/18591/share/cassandra/libexec/../pylib/cqlshlib/sslhandling.py", line 64, in ssl_settings
E             ssl_check_hostname = ssl_check_hostname is not None or ssl_check_hostname.lower() != 'false'
E                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^
E         AttributeError: 'NoneType' object has no attribute 'lower'
```