### PR TITLE
cqlsh: try server-side DESCRIBE, then client-side 

### DIFF
--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -36,6 +36,44 @@ from .ansi_colors import (ColoredText, ansi_seq, lookup_colorcode,
 CONTROL_C = '\x03'
 CONTROL_D = '\x04'
 
+def _normalize_response(response):
+    def should_keep(line):
+        if not line.strip():
+            return False
+        deprecated_options = ["dclocal_read_repair_chance", "read_repair_chance"]
+        for col in deprecated_options:
+            if col in line:
+                return False
+        ignore_options = ["paxos_grace_seconds", "tombstone_gc", "cdc"]
+        for col in ignore_options:
+            if col in line:
+                return False
+        return True
+
+    def normalize(line):
+        # normalize 0.0, 1.0 etc to 0, 1 etc.
+        line = re.sub(r"\b(\d+)\.0\b", r"\1", line)
+        # replace multiple whitespaces with a single whitespace
+        line = re.sub(r"\s+", " ", line)
+
+        line = line.rstrip(";,:")
+
+        # enforce formatting without whitespace in {ks}.{table} ({col}) and then listing items
+        line = re.sub(r"(\w+\.\w+)\s\(", r"\1(", line)
+        line = re.sub(r",\s+'", ",'", line)
+        if " PRIMARY KEY" in line:
+            return {line.replace(" PRIMARY KEY", ""), f"PRIMARY KEY ({line.split()[0]})"}
+        if ":" in line:
+            return set(line.split(":"))
+        return {line}
+
+    resp = set()
+    for s in response.split("\n"):
+        if should_keep(s):
+            resp.update(normalize(s.strip()))
+
+    return resp
+
 
 class TestCqlshOutput(BaseTestCase):
     @classmethod
@@ -726,7 +764,7 @@ class TestCqlshOutput(BaseTestCase):
                 for semicolon in (';', ''):
                     output = c.cmd_and_response('%s has_all_types%s' % (cmdword, semicolon))
                     self.assertNoHasColors(output)
-                    self.assertSequenceEqual(dedent(output).split('\n'), table_desc3.split('\n'))
+                    self.assertSetEqual(_normalize_response(dedent(output)), _normalize_response(table_desc3))
 
     def test_describe_columnfamilies_output(self):
         output_re = r'''
@@ -792,8 +830,9 @@ class TestCqlshOutput(BaseTestCase):
         output_re_client = r'''(?x)
             ^
             \n
-            Cluster: [ ] (?P<clustername> .* ) \n
-            Partitioner: [ ] (?P<partitionername> .* ) \n
+            Cluster: [ ] (?P<clustername> .* )\s?\n
+            Partitioner: [ ] (?P<partitionername> .* )\s?\n
+            Snitch: [ ] (?P<snitchname>.*)\n|^\s*$
             \n
         '''
 
@@ -1021,4 +1060,6 @@ class TestCqlshOutput(BaseTestCase):
             output = c.cmd_and_response(f"CREATE TABLE  {qks}.ccc (pkey int,  PRIMARY KEY(pkey))  WITH cdc = {{'enabled': true}};")
             self.assertEquals(output.strip(),  "")
             output = c.cmd_and_response('describe table {}.ccc'.format(qks))
-            self.assertSequenceEqual(dedent(output).split('\n'), expected.split('\n'))
+            lines = _normalize_response(dedent(output))
+            expected_lines = _normalize_response(expected)
+            self.assertTrue(expected_lines.issubset(lines), f"Output lines \n {{{lines}}} \n doesn't contain expected lines\n {{{expected_lines}}}")


### PR DESCRIPTION
Since Scylla 5.2 (https://github.com/scylladb/scylladb/commit/e6ffc220539a05cf7b2a0e37368c27075d809476) a support for server-side DESCRIBE was added. However, cqlsh did not start to use this functionality, since it is only enabled if it detects CQL version at least 4. Scylla did not increase this version number as it doesn't support all of its features, so there is a need for a different detection mechanism for server-side DESCRIBE.

This PR changes the behavior in do_describe: cqlsh will first try to execute the server-side DESCRIBE. If this fails with SyntaxException, meaning that Scylla doesn't support that command, cqlsh falls back to the client-side DESCRIBE behavior. Also I fixed tests to be in line with recent changes to output sent by Scylla.

The other possible solutions were rejected:
- Based on Scylla version: would require ugly hard-coding of versions
- Modifying Scylla to provide some indication that this feature is enabled: Scylla 5.2 is already released without it, by implementing it in another way, we'll get it out sooner
- Do a trial "DESCRIBE" at the start of connection to detect if the server supports it: if cqlsh ever supported connecting to multiple nodes (right now it uses WhiteListRoundRobinPolicy) we would have to do the check on all of the nodes in case a rolling upgrade is currently occurring and some of the nodes don't support server-side DESCRIBE.

The change was tested manually on a couple of last Scylla OSS.

Fixes https://github.com/scylladb/scylla-cqlsh/issues/17