### PR TITLE
define the the debug package is empty

### DIFF
--- a/dist/redhat/scylla-cqlsh.spec
+++ b/dist/redhat/scylla-cqlsh.spec
@@ -12,12 +12,15 @@ Requires:       python3
 AutoReqProv:    no
 Conflicts:      cassandra
 
+%global debug_package %{nil}
+
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}
 %global __brp_ldconfig %{nil}
 %global __brp_strip %{nil}
 %global __brp_strip_comment_note %{nil}
 %global __brp_strip_static_archive %{nil}
+
 
 %description
 cqlsh is a Python-based command-line client for running CQL commands on a cassandra cluster.


### PR DESCRIPTION
we need to use this global directive:
```
%global debug_package %{nil}
```

otherwise we fail with the following error, since we now don't have any debug files for debug packge:
```
Processing files: scylla-cqlsh-debugsource-6.1.0~dev-0.20240624.c7748f60c0bc.aarch64
error: Empty %files file /jenkins/workspace/scylla-master/next/scylla/tools/cqlsh/build/redhat/BUILD/scylla-cqlsh/debugsourcefiles.list
RPM build errors:
    Empty %files file /jenkins/workspace/scylla-master/next/scylla/tools/cqlsh/build/redhat/BUILD/scylla-cqlsh/debugsourcefiles.list
```