### PR TITLE
remove cassandra from the shiv package

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,7 @@ Rules-Requires-Root: no
 
 Package: %{product}-cqlsh
 Architecture: any
-Depends: python3
+Depends: %{product}-python3 (= ${binary:Version})
 Conflicts: cassandra
 Description: cqlsh is a Python-based command-line client for running CQL commands on a cassandra cluster.
 Replaces: scylla-tools (<< 5.2~rc0)

--- a/dist/redhat/scylla-cqlsh.spec
+++ b/dist/redhat/scylla-cqlsh.spec
@@ -8,7 +8,7 @@ Obsoletes:      %{product}-tools < 5.2
 License:        Apache
 URL:            http://www.scylladb.com/
 Source0:        %{reloc_pkg}
-Requires:       python3
+Requires:       %{product}-python3 = %{version}-%{release}
 AutoReqProv:    no
 Conflicts:      cassandra
 


### PR DESCRIPTION
so we can use the scylla-python3 driver version
the only problem now, we depend on new dbuild version for using newer version of scylla-driver with cqlsh.

it's really slow down the ability to update new feature that depends on new driver changes (not too many of those)

Ref: https://github.com/scylladb/scylla-python3/pull/40
Fixes: #95