### PR TITLE
cqlsh.py: change shebang to /usr/bin/env python3

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
To run python executables on scylla-python3, we need to specify /usr/bin/env python3 on shebang, otherwise the script run on /usr/bin/python3.

Fixes #97