### PR TITLE
cqlsh.py: Send DESCRIBE statement to server before parsing

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -488,7 +488,7 @@ class Shell(cmd.Cmd):
                 if os.path.exists(self.hostname) and stat.S_ISSOCK(os.stat(self.hostname).st_mode):
                     kwargs['contact_points'] = (UnixSocketEndPoint(self.hostname),)
                     self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([UnixSocketEndPoint(self.hostname)])
-                else: 
+                else:
                     kwargs['contact_points'] = (self.hostname,)
                     self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([self.hostname])
                 kwargs['port'] = self.port
@@ -1669,7 +1669,7 @@ class Shell(cmd.Cmd):
                     self.describe_element(result)
 
             except cassandra.protocol.SyntaxException:
-                # Server doesn't support DESCRIBE query, retry with 
+                # Server doesn't support DESCRIBE query, retry with
                 # client-side DESCRIBE implementation
                 self._do_describe(parsed, force_client_side_describe=True)
             except CQL_ERRORS as err:
@@ -2520,7 +2520,7 @@ def read_options(cmdlineargs, environment):
             parser.error("Cannot use --cloudconf with hostname or port")
         if options.ssl:
             parser.error("Cannot use --cloudconf with --ssl. Cloud connection encryption parameters are provided by cloud config bundle.")
-            
+
 
     hostname = option_with_default(configs.get, 'connection', 'hostname', DEFAULT_HOST)
     port = option_with_default(configs.get, 'connection', 'port', DEFAULT_PORT)

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -1061,14 +1061,14 @@ class TestCqlshOutput(BaseTestCase):
             AND min_index_interval = 128
             AND read_repair_chance = 0.0
             AND speculative_retry = '99.0PERCENTILE';
-        
+
         cdc = {{'delta': 'full', 'enabled': 'true', 'postimage': 'false', 'preimage': 'false', 'ttl': '86400'}}
         """)
 
         with testrun_cqlsh(tty=True, env=self.default_env) as c:
 
             output = c.cmd_and_response(f"CREATE TABLE  {qks}.ccc (pkey int,  PRIMARY KEY(pkey))  WITH cdc = {{'enabled': true}};")
-            self.assertEquals(output.strip(),  "")
+            self.assertEqual(output.strip(),  "")
             output = c.cmd_and_response('describe table {}.ccc'.format(qks))
             lines = _normalize_response(dedent(output))
             expected_lines = _normalize_response(expected)

--- a/pylib/cqlshlib/test/test_formatting.py
+++ b/pylib/cqlshlib/test/test_formatting.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import string
+
+from .basecase import BaseTestCase
+from .cassconnect import (get_cassandra_connection, create_keyspace, remove_db, testrun_cqlsh)
+
+
+class TestFormatting(BaseTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        s = get_cassandra_connection().connect()
+        s.default_timeout = 60.0
+        create_keyspace(s)
+        s.execute('CREATE TABLE t (k int PRIMARY KEY, v text)')
+
+        env = os.environ.copy()
+        env['LC_CTYPE'] = 'UTF-8'
+        cls.default_env = env
+
+    @classmethod
+    def tearDownClass(cls):
+        remove_db()
+
+    def test_multiple_semicolons_in_describe(self):
+        with testrun_cqlsh(tty=True, env=self.default_env) as c:
+            v1 = 'type_name'
+            v2 = 'value_name'
+            _ = c.cmd_and_response(f'CREATE TYPE "{v1}" ( "{v2}" int );')
+            output = c.cmd_and_response('DESC TYPES;;;')
+            self.assertIn(v1, output)
+            output = c.cmd_and_response(f'DESC TYPE "{v1}";;;')
+            self.assertIn(v2, output)
+
+    def test_spaces_in_describe(self):
+        with testrun_cqlsh(tty=True, env=self.default_env) as c:
+            v1 = 'type_name'
+            v2 = 'value_name'
+            _ = c.cmd_and_response(f'CREATE TYPE "{v1}" ( "{v2}" int );')
+
+            def verify_output(prefix_str: str, infix_str: str, suffix_str: str) -> None:
+                output = c.cmd_and_response(f'DESC{prefix_str}TYPES{suffix_str};')
+                self.assertIn(v1, output)
+                output = c.cmd_and_response(f'DESC{prefix_str}TYPE{infix_str}"{v1}"{suffix_str};')
+                self.assertIn(v2, output)
+
+            # cqlsh doesn't work well with whitespace characters other than spaces apparently.
+            spaces = [' ', '  ', '   ']
+            for prefix in spaces:
+                for infix in spaces:
+                    for suffix in [*spaces, '']:
+                        verify_output(prefix, infix, suffix)


### PR DESCRIPTION
Attempting to parse a DESCRIBE statement before performing
it forces us to update cqlsh whenever a new element of
the schema that could be described is introduced. We should
try to rely on the server and only in the case of a failure
(when the version of the server is old and it doesn't
recognize the query) should we try to parse it and perform
locally.

Trying to parse it first may lead to rejecting DESCRIBE
statements that would otherwise be valid -- if the grammar
used by cqlsh hasn't caught up with Scylla yet.

Fixes scylladb/scylla-cqlsh#100