### PR TITLE
cython: fix the usage of cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ ccm start
 pytest
 ```
 
+## Build from source
+
+```bash
+pip install build
+# optionally can disable the usage of cython
+# export CQLSH_NO_CYTHON=true
+python -m build -w
+...
+Successfully built scylla_cqlsh-6.0.24.dev0+gb09bc79361.d20240910-py3-none-any.whl
+```
 
 ## Creation of the repo
 

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -15,29 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import sys
+import os
 import warnings
 from distutils.core import setup, Extension
-from setuptools.command.build_ext import build_ext
-
-
-class BuildExtCommand(build_ext):
-    user_options = build_ext.user_options + [
-        ('disable-copyutil=', None, None),  # a 'flag' option
-    ]
-
-    def initialize_options(self):
-        self.disable_copyutil = None
-        super().initialize_options()
-
-    def finalize_options(self, *args, **kwargs):
-        super().finalize_options(*args, **kwargs)
-        if not self.disable_copyutil:
-            self.extensions = []
 
 
 def get_extensions():
+    if os.environ.get('CQLSH_NO_CYTHON'):
+        return []
     try:
         from Cython.Build import cythonize
         extensions = [Extension(name='copyutil',
@@ -63,7 +48,4 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
     ],
-    cmdclass={
-        'build_ext': BuildExtCommand,
-    }
 )

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -81,7 +81,7 @@ fi
 
 python3 -m pip install ${PIP_EXTRA_OPTS} shiv==1.0.6 build==0.10.0 wheel==0.37.1 -t ./build/cqlsh_build
 
-PYTHONPATH=$(pwd)/build/cqlsh_build python3 -m shiv -c cqlsh -o bin/cqlsh -- . -c requirements.txt --config-settings=--disable-copyutil=true
+CQLSH_NO_CYTHON=true PYTHONPATH=$(pwd)/build/cqlsh_build python3 -m shiv -c cqlsh -o bin/cqlsh -- . -c requirements.txt
 
 dist/debian/debian_files_gen.py
 scripts/create-relocatable-package.py --version $VERSION "$DEST"


### PR DESCRIPTION
in the change to make cqlsh platfrom specific, we introduce an option to disable cython compilation phase.
that option was broken and disable cython completly, which in turn broken the cibuildwheel process, since wheel didn't have any compiled parts any more.

this change switch the disable option to be base on environment variable cause of a lack alternatives

Ref: https://discuss.python.org/t/explicit-optional-cythonization-via-config-setting-post-pep517-and-install-option-deprecation/25379