### PR TITLE
dist: support smooth upgrade from enterprise to source availalbe

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -11,5 +11,14 @@ Architecture: any
 Depends: %{product}-python3 (= ${binary:Version})
 Conflicts: cassandra
 Description: cqlsh is a Python-based command-line client for running CQL commands on a cassandra cluster.
-Replaces: scylla-tools (<< 5.2~rc0)
-Breaks: scylla-tools (<< 5.2~rc0)
+Replaces: scylla-tools (<< 5.2~rc0), scylla-enterprise-cqlsh (<< 2025.1.0~)
+Breaks: scylla-tools (<< 5.2~rc0), scylla-enterprise-cqlsh (<< 2025.1.0~)
+
+
+Package: scylla-enterprise-cqlsh
+Depends: %{product}-cqlsh (= ${binary:Version})
+Architecture: all
+Priority: optional
+Section: oldlibs
+Description: transitional package
+ This is a transitional package. It can safely be removed.

--- a/dist/redhat/scylla-cqlsh.spec
+++ b/dist/redhat/scylla-cqlsh.spec
@@ -4,6 +4,8 @@ Release:        %{release}%{?dist}
 Summary:        cqlsh is a Python-based command-line client for running CQL commands on a cassandra cluster.
 Group:          Applications/Databases
 Obsoletes:      %{product}-tools < 5.2
+Provides:       scylla-enterprise-cqlsh = %{version}-%{release}
+Obsoletes:      scylla-enterprise-cqlsh < 2025.1.0
 
 License:        Apache
 URL:            http://www.scylladb.com/


### PR DESCRIPTION
When upgrading for example from `2024.1` to `2025.1` the package name is not identical casuing the upgrade command to fail.

This makes packages upgradable from enterprise.

Related scylladb/scylladb#22420