### PR TITLE
default to setuptools_scm based version when not packaged

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -160,7 +160,13 @@ from cqlshlib.util import is_file_secure, trim_if_present
 try:
     from cqlshlib._version import __version__ as version
 except ImportError:
-    version = "0.0.0"
+    # Get the version relative to the current file, suppressing UserWarnings from setuptools_scm
+    from setuptools_scm import get_version
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        version = get_version(root='..', relative_to=__file__, tag_regex=r'^(?P<prefix>v)?(?P<version>[^\+-]+)(?P<suffix>-scylla)?$')
+
 
 DEFAULT_HOST = '127.0.0.1'
 DEFAULT_PORT = 9042


### PR DESCRIPTION
so far if it wasn't package version of cqlsh, the version from `cqlsh --version` would retun 0.0.0

with this change we'll use setuptools_scm to generate the version string in runtime, it assume it's done within a git repository, otherwise it would fail

Fixes: #124