### PR TITLE
build-push.yml: skip python 3.8 and PyPy builds

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  CIBW_SKIP: cp36*
+  CIBW_SKIP: cp36* cp37* cp38* pp*
 
 jobs:
   build_wheels:


### PR DESCRIPTION
python 3.8 is now deprecated, and PyPy are not really in use we can skip them as they are causing build issues from time to time