### PR TITLE
Add LZ4 as a required package - so ScyllaDB Python driver could use L…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 scylla-driver==3.28.2
 PyYAML>=6.0.1
 click>=8.1.3
+lz4


### PR DESCRIPTION
…Z4 compression

Apparently, the Python driver doesn't have such a requirement, and thus this is not provided. It'd be great if cqlsh would be able to, by default, use LZ4 compression.

Adding the dependency should be enough to do it - the Python driver will be happy to import it.

NOT TESTED.