### PR TITLE
github actions: replace macos-13 with macos-15-intel

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
since macos-13 is gonna be retired soon, moving to newer versions that support x86

Fixes: #130 