### PR TITLE
github actions: update cibuildwheel to latest

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  CIBW_SKIP: cp36* cp37* cp38* pp*
+  CIBW_SKIP: cp36* cp37* cp38* cp39* pp*
 
 jobs:
   build_wheels:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.3
+        uses: pypa/cibuildwheel@v3.2.1
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
* so we can build python 3.14 wheels
* stop building for python 3.9 since it's about to be EOL