### PR TITLE
Update scylla-driver version to 3.29.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scylla-driver==3.28.2
+scylla-driver==3.29.4
 PyYAML>=6.0.1
 click>=8.1.3
 lz4


### PR DESCRIPTION
While working on https://github.com/scylladb/scylladb/pull/26740, I hit a serialization error for columns that are vectors of collections (e.g., `vector<set<int>, 1>`). This is a known bug in the Python driver, which is fixed in scylla-driver 3.29.2.

This commit updates this dependency to the latest version.

References: https://github.com/scylladb/scylladb/issues/26704