### PR TITLE
copyutil: adjust multiprocessing method to 'fork'

### DIFF
--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -32,6 +32,12 @@ import threading
 import time
 import traceback
 
+# Python 3.14 changed the default to 'forkserver', which is not compatible
+# with our relocatable python. It execs our Python binary, but without our
+# ld.so. Change it back to 'fork' to avoid issues.
+mp.set_start_method('fork')
+
+
 from bisect import bisect_right
 from calendar import timegm
 from collections import defaultdict, namedtuple


### PR DESCRIPTION
Python 3.14 changed the multiprocessing fork mode to "forkserver", presumably for good reasons. However, it conflicts with our relocatable Python system. "forkserver" forks and execs a Python process at startup, but it does this without supplying our relocated ld.so. The system ld.so detects a conflict and crashes.

Fix this by switching back to "fork", which is sufficient for cqlsh's copyutil modest needs.

A similar fix was done for ScyllaDB [1].

[1] https://github.com/scylladb/scylladb/commit/8e480110c28d2fd8523b4edd368987fc42a226b1