### PR TITLE
Revert "Migrate workflows to Blacksmith"

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -36,7 +36,7 @@ jobs:
   build_sdist:
     name: Build source distribution
     if: contains(github.event.pull_request.labels.*.name, 'test-build') || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -52,10 +52,7 @@ jobs:
   integration_test_scylla:
     name: Integration Tests (Scylla)
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-test')"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-       FORCE_COLOR: 1
-       TERM: xterm-256color
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -78,10 +75,7 @@ jobs:
   integration_test_scylla_enterprise:
     name: Integration Tests (Scylla Enterprise)
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-test')"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-       FORCE_COLOR: 1
-       TERM: xterm-256color
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -104,11 +98,7 @@ jobs:
   integration_test_cassandra:
     name: Integration Tests (Cassandra)
     if: "!contains(github.event.pull_request.labels.*.name, 'disable-integration-test')"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-       FORCE_COLOR: 1
-       TERM: xterm-256color
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -129,7 +119,7 @@ jobs:
           pytest ./cqlshlib/test
 
   docker:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
       - name: Checkout
@@ -138,8 +128,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -157,7 +147,7 @@ jobs:
 
       - name: Build and push release
         if: endsWith(github.event.ref, '-scylla')
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -168,7 +158,7 @@ jobs:
             scylladb/scylla-cqlsh:latest
 
       - name: Build and push master
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         if: endsWith(github.event.ref, 'master')
         with:
           context: .
@@ -180,7 +170,7 @@ jobs:
 
   upload_pypi:
     needs: [build_wheels, build_sdist, integration_test_scylla, integration_test_cassandra]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
     # alternatively, to publish when a GitHub Release is created, use the following rule:

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/dockerhub-description.yml
 jobs:
   dockerHubDescription:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
seems it's not needed by OSS repos

This reverts commit 72598fcd5a5a8a326f8a257f9741c1725d6a33e5.