### PR TITLE
Update scylla-driver version to 3.29.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scylla-driver==3.29.4
+scylla-driver==3.29.6
 PyYAML>=6.0.1
 click>=8.1.3
 lz4


### PR DESCRIPTION
This update is required to support the CLIENT_ROUTES_CHANGE event type, which was introduced in scylla-driver 3.29.6 and is needed for ScyllaDB development.