### PR TITLE
Fix completion tests to handle Scylla's audit keyspace

### DIFF
--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -75,11 +75,19 @@ class CqlshCompletionCase(BaseTestCase):
     def tearDown(self):
         self.cqlsh_runner.__exit__(None, None, None)
 
+    def _extra_keyspaces(self):
+        keyspaces = []
+
+        if self.is_scylla:
+            keyspaces += ['audit']
+        return keyspaces
+
     def _system_keyspaces(self):
         tables = []
 
         if self.is_scylla:
             tables += ['system_distributed_everywhere.']
+            tables += ['audit.']
             if  self.is_scylla_enterprise:
                 tables += ['system_replicated_keys.']
         else:
@@ -586,7 +594,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DROP K', immediate='EYSPACE ')
         quoted_keyspace = '"' + self.cqlsh.keyspace + '"'
         self.trycompletions('DROP KEYSPACE ',
-                            choices=['IF', self.cqlsh.keyspace])
+                            choices=['IF', self.cqlsh.keyspace] + self._extra_keyspaces())
 
         self.trycompletions('DROP KEYSPACE ' + quoted_keyspace,
                             choices=[';'])
@@ -601,7 +609,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         prefix = 'CREATE ' + name + ' '
         quoted_keyspace = '"' + self.cqlsh.keyspace + '"'
         self.trycompletions(prefix + '',
-                            choices=['IF', self.cqlsh.keyspace, '<new_table_name>'])
+                            choices=['IF', self.cqlsh.keyspace, '<new_table_name>'] + self._extra_keyspaces())
         self.trycompletions(prefix + 'IF ',
                             immediate='NOT EXISTS ')
         self.trycompletions(prefix + 'IF NOT EXISTS ',
@@ -869,7 +877,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_alter_keyspace(self):
         self.trycompletions('ALTER KEY', 'SPACE ')
         self.trycompletions('ALTER KEYSPACE ', '', choices=[self.cqlsh.keyspace, 'system_auth',
-                                                            'system_distributed', 'system_traces', 'IF'])
+                                                            'system_distributed', 'system_traces', 'IF'
+                                                            ] + self._extra_keyspaces())
         self.trycompletions('ALTER KEYSPACE I', immediate='F EXISTS ')
         self.trycompletions('ALTER KEYSPACE system_trac', "es WITH replication = {'class': 'NetworkTopologyStrategy', ")
         self.trycompletions("ALTER KEYSPACE system_traces WITH replication = {'class': '", 'NetworkTopologyStrategy')

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -599,8 +599,13 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DROP KEYSPACE ' + quoted_keyspace,
                             choices=[';'])
 
-        self.trycompletions('DROP KEYSPACE I',
-                            immediate='F EXISTS ' + self.cqlsh.keyspace + ' ;')
+        if self.is_scylla:
+            # With the audit keyspace present, there are multiple keyspaces
+            # after IF EXISTS so it can't auto-complete the full thing
+            self.trycompletions('DROP KEYSPACE I', immediate='F EXISTS ')
+        else:
+            self.trycompletions('DROP KEYSPACE I',
+                                immediate='F EXISTS ' + self.cqlsh.keyspace + ' ;')
 
     def create_columnfamily_table_template(self, name):
         """Parameterized test for CREATE COLUMNFAMILY and CREATE TABLE. Since
@@ -613,7 +618,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions(prefix + 'IF ',
                             immediate='NOT EXISTS ')
         self.trycompletions(prefix + 'IF NOT EXISTS ',
-                            choices=['<new_table_name>', self.cqlsh.keyspace])
+                            choices=['<new_table_name>', self.cqlsh.keyspace] + self._extra_keyspaces())
         self.trycompletions(prefix + 'IF NOT EXISTS new_table ',
                             immediate='( ')
 


### PR DESCRIPTION
## Summary
- Scylla now exposes an `audit` keyspace that appears in tab completion results, causing 6 integration test failures
- Added `_extra_keyspaces()` helper for bare keyspace name contexts and `'audit.'` to `_system_keyspaces()` for table/type-qualified contexts
- Fixes: `test_complete_in_alter_keyspace`, `test_complete_in_alter_table`, `test_complete_in_alter_type`, `test_complete_in_create_columnfamily`, `test_complete_in_create_table`, `test_complete_in_drop_keyspace`

## Test plan
- [ ] CI integration tests (Scylla) pass with the `audit` keyspace present

🤖 Generated with [Claude Code](https://claude.com/claude-code)