### PR TITLE
docker: upgrade pip, setuptools, wheel, and requests to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install --no-ins
 COPY . .
 # Configure pip to retry on network failures (helps with timeout issues)
 ENV PIP_RETRIES=10
+# Upgrade build tools to address CVEs in pip, setuptools, and wheel
+RUN pip install --no-cache-dir --upgrade pip==26.1 setuptools==82.0.1 wheel==0.47.0
 RUN pip install --user .
 
 
@@ -15,7 +17,7 @@ FROM python:3.13-slim-bullseye AS build-image
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 # Configure pip to retry on network failures (helps with timeout issues)
 ENV PIP_RETRIES=10
-RUN pip install --upgrade --no-cache-dir pip
+RUN pip install --upgrade --no-cache-dir pip==26.1 setuptools==82.0.1 wheel==0.47.0 requests==2.33.1
 
 COPY --from=compile-image /root/.local /root/.local
 

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -82,7 +82,7 @@ fi
 # Configure pip to retry on network failures (helps with timeout issues)
 export PIP_RETRIES=10
 
-python3 -m pip install ${PIP_EXTRA_OPTS} shiv==1.0.6 build==0.10.0 wheel==0.37.1 -t ./build/cqlsh_build
+python3 -m pip install ${PIP_EXTRA_OPTS} shiv==1.0.6 build==0.10.0 wheel==0.46.0 -t ./build/cqlsh_build
 
 CQLSH_NO_CYTHON=true PYTHONPATH=$(pwd)/build/cqlsh_build python3 -m shiv -c cqlsh -o bin/cqlsh -- . -c requirements.txt
 


### PR DESCRIPTION
Upgrade vulnerable Python packages in the Docker image:
- pip 21.3.1: CVE-2023-5752, CVE-2025-8869, CVE-2026-1703
- setuptools 53.0.0: CVE-2025-47273, CVE-2024-6345
- wheel 0.45.1/0.37.1: CVE-2026-24049
- requests 2.32.5: CVE-2026-25645