### PR TITLE
Update scylla-driver to 3.29.11

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Start Scylla
         run: |
           export DOCKER_ID=$(docker run -d scylladb/scylla:latest --cluster-name test )
-          export CQL_TEST_HOST=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' ${DOCKER_ID})
+          export CQL_TEST_HOST=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${DOCKER_ID})
           while ! nc -z ${CQL_TEST_HOST} 9042; do   
             sleep 0.1 # wait for 1/10 of the second before check again
           done
@@ -75,6 +75,7 @@ jobs:
           pip install -r ./pylib/requirements.txt
            ./reloc/build_reloc.sh
           pytest ./cqlshlib/test
+          ./scripts/run-proxy-access-test.sh
 
   integration_test_cassandra:
     name: Integration Tests (Cassandra)
@@ -86,7 +87,7 @@ jobs:
       - name: Start Scylla
         run: |
           export DOCKER_ID=$(docker run -d -e CASSANDRA_CLUSTER_NAME=test cassandra:5.0 )
-          export CQL_TEST_HOST=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' ${DOCKER_ID})
+          export CQL_TEST_HOST=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${DOCKER_ID})
           while ! nc -z ${CQL_TEST_HOST} 9042; do
                   sleep 0.1 # wait for 1/10 of the second before check again
           done

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -152,7 +152,7 @@ from cqlshlib.formatting import (DEFAULT_DATE_FORMAT, DEFAULT_NANOTIME_FORMAT,
                                  DEFAULT_TIMESTAMP_FORMAT, CqlType, DateTimeFormat,
                                  format_by_type)
 from cqlshlib.tracing import print_trace, print_trace_session
-from cqlshlib.util import get_file_encoding_bomsize
+from cqlshlib.util import control_connection_query_fallback_kwargs, get_file_encoding_bomsize
 from cqlshlib.util import is_file_secure, trim_if_present
 
 try:
@@ -502,6 +502,7 @@ class Shell(cmd.Cmd):
             kwargs['ssl_context'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
             # workaround until driver would know not to lose the DNS names for `server_hostname`
             kwargs['ssl_options'] = {'server_hostname': self.hostname} if ssl else None
+            kwargs.update(control_connection_query_fallback_kwargs())
             
             # Disable compression if requested. When not set, the driver will use its default
             # compression behavior (which is to enable compression if lz4 is available)
@@ -2184,6 +2185,7 @@ class Shell(cmd.Cmd):
         kwargs['port'] = self.port
         kwargs['ssl_context'] = self.conn.ssl_context
         kwargs['ssl_options'] = self.conn.ssl_options
+        kwargs.update(control_connection_query_fallback_kwargs())
         
         # Preserve compression setting from original connection
         if self.no_compression:

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -57,7 +57,7 @@ from cassandra.metadata import protect_name, protect_names, protect_value
 from cassandra.policies import RetryPolicy, WhiteListRoundRobinPolicy, DCAwareRoundRobinPolicy, FallthroughRetryPolicy
 from cassandra.query import BatchStatement, BatchType, SimpleStatement, tuple_factory
 from cassandra.util import Date, Time
-from cqlshlib.util import profile_on, profile_off
+from cqlshlib.util import control_connection_query_fallback_kwargs, profile_on, profile_off
 
 from cqlshlib.cql3handling import CqlRuleSet
 from cqlshlib.displaying import NO_COLOR_MAP
@@ -1717,6 +1717,7 @@ class ExportProcess(ChildProcess):
             compression=None,
             control_connection_timeout=self.connect_timeout,
             connect_timeout=self.connect_timeout,
+            **control_connection_query_fallback_kwargs(),
             idle_heartbeat_interval=0)
         session = ExportSession(new_cluster, self)
         self.hosts_to_sessions[host] = session
@@ -2389,6 +2390,7 @@ class ImportProcess(ChildProcess):
                 compression=None,
                 control_connection_timeout=self.connect_timeout,
                 connect_timeout=self.connect_timeout,
+                **control_connection_query_fallback_kwargs(),
                 idle_heartbeat_interval=0,
                 connection_class=ConnectionWrapper)
 

--- a/pylib/cqlshlib/test/test_proxy_access.py
+++ b/pylib/cqlshlib/test/test_proxy_access.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from .cassconnect import testcall_cqlsh as call_cqlsh_for_test
+
+
+@pytest.mark.skipif(
+    not os.environ.get('CQL_PROXY_TEST_HOST'),
+    reason='proxy access test is opt-in')
+def test_proxy_access_without_rewriting_broadcast_address():
+    env = os.environ.copy()
+    env['COLUMNS'] = '100000'
+    env.setdefault('LC_CTYPE', 'en_US.utf8')
+
+    query = "SELECT broadcast_address FROM system.local WHERE key = 'local';"
+    output, result = call_cqlsh_for_test(
+        keyspace=None,
+        prompt=None,
+        env=env,
+        tty=False,
+        host=os.environ['CQL_PROXY_TEST_HOST'],
+        port=os.environ.get('CQL_PROXY_TEST_PORT', '9042'),
+        input=query + '\n')
+
+    assert result == 0, output
+    assert 'broadcast_address' in output
+
+    blocked_host = os.environ.get('CQL_PROXY_TEST_BLOCKED_HOST')
+    if blocked_host:
+        assert blocked_host in output

--- a/pylib/cqlshlib/test/test_util.py
+++ b/pylib/cqlshlib/test/test_util.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+import cassandra.cluster
+
+from cqlshlib.util import control_connection_query_fallback_kwargs
+
+
+class ControlConnectionQueryFallbackTest(unittest.TestCase):
+
+    def test_returns_no_kwargs_for_driver_without_fallback(self):
+        original = getattr(cassandra.cluster, 'ControlConnectionQueryFallback', None)
+        had_fallback = hasattr(cassandra.cluster, 'ControlConnectionQueryFallback')
+        if had_fallback:
+            delattr(cassandra.cluster, 'ControlConnectionQueryFallback')
+
+        try:
+            self.assertEqual(control_connection_query_fallback_kwargs(), {})
+        finally:
+            if had_fallback:
+                cassandra.cluster.ControlConnectionQueryFallback = original
+
+    def test_enables_fallback_for_driver_with_fallback(self):
+        class ControlConnectionQueryFallback(object):
+            Fallback = object()
+
+        with patch.object(cassandra.cluster, 'ControlConnectionQueryFallback',
+                          ControlConnectionQueryFallback, create=True):
+            self.assertEqual(
+                control_connection_query_fallback_kwargs(),
+                {'allow_control_connection_query_fallback': ControlConnectionQueryFallback.Fallback})

--- a/pylib/cqlshlib/util.py
+++ b/pylib/cqlshlib/util.py
@@ -114,6 +114,17 @@ def trim_if_present(s, prefix):
     return s
 
 
+def control_connection_query_fallback_kwargs():
+    try:
+        from cassandra.cluster import ControlConnectionQueryFallback
+    except ImportError:
+        return {}
+
+    return {
+        'allow_control_connection_query_fallback': ControlConnectionQueryFallback.Fallback
+    }
+
+
 def is_file_secure(filename):
     try:
         st = os.stat(filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scylla-driver==3.29.7
+scylla-driver==3.29.11
 PyYAML>=6.0.1
 click>=8.1.3
 lz4

--- a/scripts/run-proxy-access-test.sh
+++ b/scripts/run-proxy-access-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CQL_TEST_HOST:?CQL_TEST_HOST must point at the Scylla node IP}"
+CQL_TEST_PORT="${CQL_TEST_PORT:-9042}"
+
+proxy_container="cqlsh-proxy-access-${GITHUB_RUN_ID:-local}-$$"
+direct_rule_added=0
+
+cleanup() {
+    if [ "${direct_rule_added}" = 1 ]; then
+        sudo iptables -w -D OUTPUT -p tcp -d "${CQL_TEST_HOST}" --dport "${CQL_TEST_PORT}" -j REJECT >/dev/null 2>&1 || true
+    fi
+    docker rm -f "${proxy_container}" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+docker run -d --name "${proxy_container}" -p 127.0.0.1::9042 busybox sh -c \
+    "while true; do nc -lp 9042 -e nc ${CQL_TEST_HOST} ${CQL_TEST_PORT}; done" >/dev/null
+
+proxy_port="$(docker port "${proxy_container}" 9042/tcp | awk -F: '{print $NF; exit}')"
+
+for _ in $(seq 1 100); do
+    if nc -z 127.0.0.1 "${proxy_port}"; then
+        proxy_ready=1
+        break
+    fi
+    sleep 0.1
+done
+
+if [ "${proxy_ready:-0}" != 1 ]; then
+    echo "Proxy did not start listening on 127.0.0.1:${proxy_port}" >&2
+    exit 1
+fi
+
+sudo iptables -w -I OUTPUT -p tcp -d "${CQL_TEST_HOST}" --dport "${CQL_TEST_PORT}" -j REJECT
+direct_rule_added=1
+
+CQL_PROXY_TEST_HOST=127.0.0.1 \
+CQL_PROXY_TEST_PORT="${proxy_port}" \
+CQL_PROXY_TEST_BLOCKED_HOST="${CQL_TEST_HOST}" \
+    pytest ./cqlshlib/test/test_proxy_access.py


### PR DESCRIPTION
## Summary
- update the pinned scylla-driver dependency to 3.29.11
- enable ControlConnectionQueryFallback.Fallback for cqlsh-created Cluster instances when the installed driver supports it
- keep compatibility with older scylla-driver versions by omitting the new keyword when the enum is unavailable

This addresses the compatibility concern from https://github.com/scylladb/scylla-cqlsh/pull/173#issuecomment-4422899197.

## Tests
- python3 -m py_compile pylib/cqlshlib/util.py pylib/cqlshlib/copyutil.py bin/cqlsh.py pylib/cqlshlib/test/test_util.py
- python3 -m pytest pylib/cqlshlib/test/test_util.py
- temp venv with scylla-driver==3.29.11: verified helper kwargs are accepted by Cluster