### PR TITLE
Add client routes configuration to cqlsh

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -134,9 +134,14 @@ from cassandra.connection import UnixSocketEndPoint
 from cassandra.cqltypes import cql_typename
 from cassandra.marshal import int64_unpack
 from cassandra.metadata import (ColumnMetadata, KeyspaceMetadata, TableMetadata, protect_name, protect_names)
-from cassandra.policies import WhiteListRoundRobinPolicy
+from cassandra.policies import RoundRobinPolicy, WhiteListRoundRobinPolicy
 from cassandra.query import SimpleStatement, ordered_dict_factory, TraceUnavailable
 from cassandra.util import datetime_from_timestamp
+try:
+    from cassandra.client_routes import ClientRouteProxy, ClientRoutesConfig
+except ImportError:
+    ClientRouteProxy = None
+    ClientRoutesConfig = None
 
 # cqlsh should run correctly when run out of a Cassandra source tree,
 # out of an unpacked Cassandra tarball, and after a proper package install.
@@ -201,6 +206,15 @@ parser.add_option("--browser", dest='browser', help="""The browser to use to dis
                                                     - browser path followed by %s, example: /usr/bin/google-chrome-stable %s""")
 parser.add_option('--ssl', action='store_true', help='Use SSL', default=False)
 parser.add_option('--no-compression', action='store_true', help='Disable compression', default=False)
+parser.add_option('--client-route', action='append', dest='client_routes',
+                  metavar='CONNECTION_ID[=ADDRESS]',
+                  help='Enable client routes. Repeat for each CONNECTION_ID[=ADDRESS].')
+parser.add_option('--client-routes-advanced-shard-awareness', action='store_true',
+                  dest='client_routes_advanced_shard_awareness',
+                  help='Use shard-aware ports with client routes.')
+parser.add_option('--no-client-routes-advanced-shard-awareness', action='store_false',
+                  dest='client_routes_advanced_shard_awareness',
+                  help='Do not use shard-aware ports with client routes.')
 parser.add_option("-u", "--username", help="Authenticate as user.")
 parser.add_option("-p", "--password", help="Authenticate using password.")
 parser.add_option('-k', '--keyspace', help='Authenticate to the given keyspace.')
@@ -459,6 +473,8 @@ class Shell(cmd.Cmd):
                  is_subshell=False,
                  auth_provider=None,
                  no_compression=False,
+                 client_routes_config=None,
+                 contact_points=None,
                  ):
         cmd.Cmd.__init__(self, completekey=completekey)
         self.hostname = hostname
@@ -466,6 +482,8 @@ class Shell(cmd.Cmd):
         self.auth_provider = auth_provider
         self.username = username
         self.no_compression = no_compression
+        self.client_routes_config = client_routes_config
+        self.contact_points = tuple(contact_points) if contact_points else (self.hostname,)
 
         if isinstance(auth_provider, PlainTextAuthProvider):
             self.username = auth_provider.username
@@ -493,11 +511,18 @@ class Shell(cmd.Cmd):
             }
 
             if self.is_unix_socket(self.hostname):
-                kwargs['contact_points'] = (UnixSocketEndPoint(self.hostname),)
-                self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([UnixSocketEndPoint(self.hostname)])
+                self.contact_points = (UnixSocketEndPoint(self.hostname),)
+                kwargs['contact_points'] = self.contact_points
+                if client_routes_config is None:
+                    self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy(self.contact_points)
             else:
-                kwargs['contact_points'] = (self.hostname,)
-                self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy([self.hostname])
+                self.contact_points = tuple(contact_points) if contact_points else (self.hostname,)
+                kwargs['contact_points'] = self.contact_points
+                if client_routes_config is None:
+                    self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = WhiteListRoundRobinPolicy(self.contact_points)
+            if client_routes_config is not None:
+                kwargs['client_routes_config'] = client_routes_config
+                self.profiles[EXEC_PROFILE_DEFAULT].load_balancing_policy = RoundRobinPolicy()
             kwargs['port'] = self.port
             kwargs['ssl_context'] = sslhandling.ssl_settings(hostname, CONFIG_FILE) if ssl else None
             # workaround until driver would know not to lose the DNS names for `server_hostname`
@@ -2181,10 +2206,12 @@ class Shell(cmd.Cmd):
         auth_provider = PlainTextAuthProvider(username=username, password=password)
 
         kwargs = {}
-        kwargs['contact_points'] = (self.hostname,)
+        kwargs['contact_points'] = self.contact_points
         kwargs['port'] = self.port
         kwargs['ssl_context'] = self.conn.ssl_context
         kwargs['ssl_options'] = self.conn.ssl_options
+        if self.client_routes_config is not None:
+            kwargs['client_routes_config'] = self.client_routes_config
         kwargs.update(control_connection_query_fallback_kwargs())
         
         # Preserve compression setting from original connection
@@ -2441,6 +2468,59 @@ def raw_option_with_default(configs, section, option, default=None):
         return default
 
 
+def parse_client_route_spec(spec):
+    spec = spec.strip()
+    if not spec:
+        raise ValueError("client route must not be empty")
+
+    connection_id, separator, address_override = spec.partition('=')
+    connection_id = connection_id.strip()
+    if not connection_id:
+        raise ValueError("client route %r has empty connection id" % (spec,))
+
+    if not separator:
+        return connection_id, None
+
+    address_override = address_override.strip()
+    if not address_override:
+        raise ValueError("client route %r has empty address override" % (spec,))
+
+    return connection_id, address_override
+
+
+def parse_client_routes(value):
+    if not value:
+        return []
+
+    if isinstance(value, (list, tuple)):
+        raw_specs = []
+        for item in value:
+            raw_specs.extend(re.split(r'[\n,]+', item))
+    else:
+        raw_specs = re.split(r'[\n,]+', value)
+
+    routes = []
+    for spec in raw_specs:
+        if not spec or not spec.strip():
+            continue
+        routes.append(parse_client_route_spec(spec))
+    return routes
+
+
+def build_client_routes_config(routes, advanced_shard_awareness):
+    if not routes:
+        return None
+
+    if ClientRouteProxy is None or ClientRoutesConfig is None:
+        parser.error("Installed Scylla Python driver does not support client routes.")
+
+    proxies = [ClientRouteProxy(connection_id, address_override)
+               for connection_id, address_override in routes]
+    return ClientRoutesConfig(
+        proxies=proxies,
+        advanced_shard_awareness=advanced_shard_awareness)
+
+
 def should_use_color():
     if not sys.stdout.isatty():
         return False
@@ -2500,6 +2580,11 @@ def read_options(cmdlineargs, environment):
     optvalues.max_trace_wait = option_with_default(configs.getfloat, 'tracing', 'max_trace_wait',
                                                    DEFAULT_MAX_TRACE_WAIT)
     optvalues.timezone = option_with_default(configs.get, 'ui', 'timezone', None)
+    try:
+        config_client_routes = parse_client_routes(
+            raw_option_with_default(rawconfigs, 'client_routes', 'proxies', ''))
+    except ValueError as e:
+        parser.error(str(e))
 
     optvalues.debug = False
     optvalues.driver_debug = False
@@ -2510,6 +2595,9 @@ def read_options(cmdlineargs, environment):
     optvalues.file = None
     optvalues.ssl = option_with_default(configs.getboolean, 'connection', 'ssl', DEFAULT_SSL)
     optvalues.no_compression = option_with_default(configs.getboolean, 'connection', 'no_compression', False)
+    optvalues.client_routes = None
+    optvalues.client_routes_advanced_shard_awareness = option_with_default(
+        configs.getboolean, 'client_routes', 'advanced_shard_awareness', False)
     optvalues.encoding = option_with_default(configs.get, 'ui', 'encoding', UTF8)
 
     optvalues.tty = option_with_default(configs.getboolean, 'ui', 'tty', sys.stdin.isatty())
@@ -2521,6 +2609,18 @@ def read_options(cmdlineargs, environment):
     optvalues.insecure_password_without_warning = False
 
     (options, arguments) = parser.parse_args(cmdlineargs, values=optvalues)
+
+    try:
+        if options.client_routes is None:
+            options.client_routes = config_client_routes
+        else:
+            options.client_routes = parse_client_routes(options.client_routes)
+    except ValueError as e:
+        parser.error(str(e))
+
+    options.client_routes_config = build_client_routes_config(
+        options.client_routes,
+        options.client_routes_advanced_shard_awareness)
 
     # Credentials from cqlshrc will be expanded,
     # credentials from the command line are also expanded if there is a space...
@@ -2563,8 +2663,10 @@ def read_options(cmdlineargs, environment):
     options.password = maybe_ensure_text(options.password)
     options.keyspace = maybe_ensure_text(options.keyspace)
 
-    hostname = option_with_default(configs.get, 'connection', 'hostname', DEFAULT_HOST)
+    config_hostname = option_with_default(configs.get, 'connection', 'hostname')
+    hostname = config_hostname or DEFAULT_HOST
     port = option_with_default(configs.get, 'connection', 'port', DEFAULT_PORT)
+    host_was_explicit = config_hostname is not None
 
     try:
         options.connect_timeout = int(options.connect_timeout)
@@ -2578,13 +2680,23 @@ def read_options(cmdlineargs, environment):
         parser.error('"%s" is not a valid request timeout.' % (options.request_timeout,))
         options.request_timeout = DEFAULT_REQUEST_TIMEOUT_SECONDS
 
-    hostname = environment.get('CQLSH_HOST', hostname)
+    if 'CQLSH_HOST' in environment:
+        hostname = environment['CQLSH_HOST']
+        host_was_explicit = True
     port = environment.get('CQLSH_PORT', port)
 
     if len(arguments) > 0:
         hostname = arguments[0]
+        host_was_explicit = True
     if len(arguments) > 1:
         port = arguments[1]
+
+    options.contact_points = None
+    if options.client_routes_config is not None and not host_was_explicit:
+        client_route_contact_points = [address for _, address in options.client_routes if address]
+        if client_route_contact_points:
+            hostname = client_route_contact_points[0]
+            options.contact_points = tuple(client_route_contact_points)
 
     if options.file or options.execute:
         options.tty = False
@@ -2674,6 +2786,7 @@ def main(options, hostname, port):
         sys.stderr.write("Using '%s' encoding\n" % (options.encoding,))
         sys.stderr.write("Using ssl: %s\n" % (options.ssl,))
         sys.stderr.write("Using compression: %s\n" % (not options.no_compression,))
+        sys.stderr.write("Using client routes: %s\n" % (options.client_routes_config is not None,))
 
     # create timezone based on settings, environment or auto-detection
     timezone = None
@@ -2737,6 +2850,8 @@ def main(options, hostname, port):
                           username=options.username,
                           password=options.password),
                       no_compression=options.no_compression,
+                      client_routes_config=options.client_routes_config,
+                      contact_points=options.contact_points,
                       )
     except KeyboardInterrupt:
         sys.exit('Connection aborted.')

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -500,6 +500,7 @@ class CopyTask(object):
         this dictionary must be picklable.
         """
         shell = self.shell
+        client_routes_config = getattr(shell, 'client_routes_config', None)
 
         return dict(ks=self.ks,
                     table=self.table,
@@ -511,6 +512,8 @@ class CopyTask(object):
                     port=shell.port,
                     ssl=shell.ssl,
                     auth_provider=shell.auth_provider,
+                    client_routes_config=client_routes_config,
+                    contact_points=getattr(shell, 'contact_points', None) if client_routes_config is not None else None,
                     cql_version=shell.conn.cql_version,
                     config_file=self.config_file,
                     protocol_version=self.protocol_version,
@@ -1438,6 +1441,8 @@ class ChildProcess(mp.Process):
         self.connect_timeout = params['connect_timeout']
         self.cql_version = params['cql_version']
         self.auth_provider = params['auth_provider']
+        self.client_routes_config = params['client_routes_config']
+        self.contact_points = params['contact_points']
         self.ssl = params['ssl']
         self.protocol_version = params['protocol_version']
         self.config_file = params['config_file']
@@ -1705,8 +1710,14 @@ class ExportProcess(ChildProcess):
             session.add_request()
             return session
 
+        kwargs = {}
+        if self.client_routes_config is not None:
+            kwargs['contact_points'] = self.contact_points
+            kwargs['client_routes_config'] = self.client_routes_config
+        else:
+            kwargs['contact_points'] = (host,)
+
         new_cluster = Cluster(
-            contact_points=(host,),
             port=self.port,
             cql_version=self.cql_version,
             protocol_version=self.protocol_version,
@@ -1718,6 +1729,7 @@ class ExportProcess(ChildProcess):
             control_connection_timeout=self.connect_timeout,
             connect_timeout=self.connect_timeout,
             **control_connection_query_fallback_kwargs(),
+            **kwargs,
             idle_heartbeat_interval=0)
         session = ExportSession(new_cluster, self)
         self.hosts_to_sessions[host] = session
@@ -2378,8 +2390,14 @@ class ImportProcess(ChildProcess):
     @property
     def session(self):
         if not self._session:
+            kwargs = {}
+            if self.client_routes_config is not None:
+                kwargs['contact_points'] = self.contact_points
+                kwargs['client_routes_config'] = self.client_routes_config
+            else:
+                kwargs['contact_points'] = (self.hostname,)
+
             cluster = Cluster(
-                contact_points=(self.hostname,),
                 port=self.port,
                 cql_version=self.cql_version,
                 protocol_version=self.protocol_version,
@@ -2391,6 +2409,7 @@ class ImportProcess(ChildProcess):
                 control_connection_timeout=self.connect_timeout,
                 connect_timeout=self.connect_timeout,
                 **control_connection_query_fallback_kwargs(),
+                **kwargs,
                 idle_heartbeat_interval=0,
                 connection_class=ConnectionWrapper)
 

--- a/pylib/cqlshlib/test/test_client_routes.py
+++ b/pylib/cqlshlib/test/test_client_routes.py
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class FakeClientRouteProxy(object):
+
+    def __init__(self, connection_id, connection_addr_override=None):
+        self.connection_id = connection_id
+        self.connection_addr_override = connection_addr_override
+
+
+class FakeClientRoutesConfig(object):
+
+    def __init__(self, proxies, advanced_shard_awareness=False):
+        self.proxies = proxies
+        self.advanced_shard_awareness = advanced_shard_awareness
+
+
+def patch_client_routes_driver(cqlsh_module):
+    return patch.multiple(
+        cqlsh_module,
+        ClientRouteProxy=FakeClientRouteProxy,
+        ClientRoutesConfig=FakeClientRoutesConfig)
+
+
+def test_parse_client_routes_accepts_ids_and_overrides(cqlsh_module):
+    assert cqlsh_module.parse_client_routes('conn-a=proxy-a.example.com,\nconn-b') == [
+        ('conn-a', 'proxy-a.example.com'),
+        ('conn-b', None),
+    ]
+
+
+def test_parse_client_routes_rejects_empty_connection_id(cqlsh_module):
+    with pytest.raises(ValueError, match='empty connection id'):
+        cqlsh_module.parse_client_routes('=proxy-a.example.com')
+
+
+def test_parse_client_routes_rejects_empty_address_override(cqlsh_module):
+    with pytest.raises(ValueError, match='empty address override'):
+        cqlsh_module.parse_client_routes('conn-a=')
+
+
+def test_read_options_uses_client_routes_from_cqlshrc(tmp_path, cqlsh_module):
+    temp_cqlshrc = tmp_path / 'cqlshrc'
+    temp_cqlshrc.write_text(
+        '[connection]\n'
+        'hostname = seed.example.com\n'
+        '[client_routes]\n'
+        'proxies = conn-a=proxy-a.example.com,\n'
+        '          conn-b\n'
+        'advanced_shard_awareness = true\n')
+
+    with patch_client_routes_driver(cqlsh_module), \
+            patch.object(cqlsh_module, 'CONFIG_FILE', str(temp_cqlshrc)):
+        options, hostname, port = cqlsh_module.read_options([], {})
+
+    assert hostname == 'seed.example.com'
+    assert options.client_routes == [
+        ('conn-a', 'proxy-a.example.com'),
+        ('conn-b', None),
+    ]
+    assert options.client_routes_config.advanced_shard_awareness is True
+    assert [p.connection_id for p in options.client_routes_config.proxies] == ['conn-a', 'conn-b']
+    assert options.client_routes_config.proxies[0].connection_addr_override == 'proxy-a.example.com'
+    assert options.client_routes_config.proxies[1].connection_addr_override is None
+
+
+def test_read_options_client_route_cli_replaces_cqlshrc(tmp_path, cqlsh_module):
+    temp_cqlshrc = tmp_path / 'cqlshrc'
+    temp_cqlshrc.write_text(
+        '[connection]\n'
+        '[client_routes]\n'
+        'proxies = config-conn=config-proxy.example.com\n')
+
+    with patch_client_routes_driver(cqlsh_module), \
+            patch.object(cqlsh_module, 'CONFIG_FILE', str(temp_cqlshrc)):
+        options, hostname, port = cqlsh_module.read_options(
+            ['--client-route', 'cli-conn=cli-proxy.example.com'], {})
+
+    assert hostname == 'cli-proxy.example.com'
+    assert options.contact_points == ('cli-proxy.example.com',)
+    assert options.client_routes == [('cli-conn', 'cli-proxy.example.com')]
+    assert [p.connection_id for p in options.client_routes_config.proxies] == ['cli-conn']
+
+
+def test_read_options_requires_driver_support_when_routes_enabled(tmp_path, cqlsh_module):
+    temp_cqlshrc = tmp_path / 'cqlshrc'
+    temp_cqlshrc.write_text('[connection]\n')
+
+    with patch.object(cqlsh_module, 'ClientRouteProxy', None), \
+            patch.object(cqlsh_module, 'ClientRoutesConfig', None), \
+            patch.object(cqlsh_module, 'CONFIG_FILE', str(temp_cqlshrc)), \
+            pytest.raises(SystemExit):
+        cqlsh_module.read_options(['--client-route', 'conn-a'], {})
+
+
+def test_read_options_allows_old_driver_when_routes_disabled(tmp_path, cqlsh_module):
+    temp_cqlshrc = tmp_path / 'cqlshrc'
+    temp_cqlshrc.write_text('[connection]\n')
+
+    with patch.object(cqlsh_module, 'ClientRouteProxy', None), \
+            patch.object(cqlsh_module, 'ClientRoutesConfig', None), \
+            patch.object(cqlsh_module, 'CONFIG_FILE', str(temp_cqlshrc)):
+        options, hostname, port = cqlsh_module.read_options([], {})
+
+    assert options.client_routes == []
+    assert options.client_routes_config is None
+
+
+def test_shell_passes_client_routes_config_to_cluster(cqlsh_module):
+    client_routes_config = FakeClientRoutesConfig(
+        [FakeClientRouteProxy('conn-a', 'proxy-a.example.com')])
+
+    with patch.object(cqlsh_module, 'Cluster') as mock_cluster:
+        mock_cluster_instance = MagicMock()
+        mock_cluster.return_value = mock_cluster_instance
+        mock_session = MagicMock()
+        mock_cluster_instance.connect.return_value = mock_session
+        mock_cluster_instance.cql_version = '3.4.5'
+        mock_cluster_instance.protocol_version = 4
+        mock_cluster_instance.metadata.keyspaces = []
+
+        def execute_side_effect(query):
+            if 'system.local' in query:
+                return [{'cql_version': '3.4.5', 'release_version': '4.0.0'}]
+            if 'system.versions' in query:
+                return [{'version': '5.0.0'}]
+            return []
+
+        mock_session.execute.side_effect = execute_side_effect
+
+        cqlsh_module.Shell(
+            'proxy-a.example.com',
+            9042,
+            client_routes_config=client_routes_config,
+            contact_points=('proxy-a.example.com', 'proxy-b.example.com'),
+            encoding='utf-8')
+
+    call_kwargs = mock_cluster.call_args[1]
+    assert call_kwargs['contact_points'] == ('proxy-a.example.com', 'proxy-b.example.com')
+    assert call_kwargs['client_routes_config'] is client_routes_config
+    profile = call_kwargs['execution_profiles'][cqlsh_module.EXEC_PROFILE_DEFAULT]
+    assert isinstance(profile.load_balancing_policy, cqlsh_module.RoundRobinPolicy)

--- a/pylib/cqlshlib/test/test_copyutil.py
+++ b/pylib/cqlshlib/test/test_copyutil.py
@@ -143,6 +143,23 @@ class TestExportTask(CopyTaskTest):
     def test_exporting_to_std(self):
         self._test_get_ranges_murmur3_base({'begintoken': MIN_LONG - 1}, {}, fname=None)
 
+    def test_make_params_includes_client_routes_for_workers(self):
+        shell = self.mock_shell()
+        shell.client_routes_config = object()
+        shell.contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+        shell.conn.metadata.partitioner = 'Murmur3Partitioner'
+        shell.get_ring.return_value = {
+            Murmur3Token(-9223372036854775808): self.hosts[0:3],
+        }
+
+        export_task = ExportTask(shell, self.ks, self.table, self.columns,
+                                 self.fname, {}, self.protocol_version, self.config_file)
+        params = export_task.make_params()
+
+        self.assertIs(params['client_routes_config'], shell.client_routes_config)
+        self.assertEqual(params['contact_points'], shell.contact_points)
+        export_task.close()
+
 
 class TestImportTask(CopyTaskTest):
     def test_validate_columns(self):
@@ -390,4 +407,3 @@ class TestImportTask(CopyTaskTest):
                 self.assertEqual(rows[2], ['row3val1', 'row3val2'])
 
             import_task.close()
-


### PR DESCRIPTION
## Summary
Client routes let cqlsh work in PrivateLink/proxy deployments where ScyllaDB node addresses from `system.local` / `system.peers` are not reachable directly. The configured `connection_id` selects rows from `system.client_routes`, and the driver maps node `host_id`s to reachable routed addresses while tracking `CLIENT_ROUTES_CHANGE` updates.

- Add cqlsh client-routes support for ScyllaDB private networking.
- Pass driver `ClientRoutesConfig` into the main shell, `LOGIN`, and `COPY` worker clusters when the installed driver supports it.
- Keep older `scylla-driver` versions working when client routes are unused; enabling client routes on an unsupported driver fails with a clear parser error.
- Use round-robin load balancing with client routes so routed endpoints are not filtered by the normal contact-point whitelist.

## CLI
```bash
cqlsh --client-route CONNECTION_ID[=ADDRESS] [host [port]]
cqlsh --client-route conn-a=proxy-a.example.com --client-route conn-b=proxy-b.example.com
```

## cqlshrc
```ini
[client_routes]
proxies = conn-a=proxy-a.example.com,
          conn-b
advanced_shard_awareness = false
```

`ADDRESS` is optional. If it is omitted, the driver uses the address from `system.client_routes`. If no explicit cqlsh host is supplied and an address override exists, cqlsh uses that override as the initial contact point.

## References
- ScyllaDB server PR for `system.client_routes` and `CLIENT_ROUTES_CHANGE`: https://github.com/scylladb/scylladb/pull/26992
- Python-driver PrivateLink issue / DRIVER-89: https://github.com/scylladb/python-driver/issues/692
- Python-driver implementation PR: https://github.com/scylladb/python-driver/pull/706
- Python-driver route-state follow-up PR: https://github.com/scylladb/python-driver/pull/853
- ScyllaDB Rust driver client-routes docs: https://rust-driver.docs.scylladb.com/stable/connecting/client-routes.html
- ScyllaDB gocql client-routes config docs: https://github.com/scylladb/gocql#52-client-routes-privatelink
- This PR commit: https://github.com/scylladb/scylla-cqlsh/pull/204/commits/56809c9fdaf94c4c65b9886f0e0b1147eab1c105

Refs scylladb/scylladb#26992
Refs scylladb/python-driver#692
Refs scylladb/python-driver#706
Refs scylladb/python-driver#853

## Tests
- `python3 -m py_compile bin/cqlsh.py pylib/cqlshlib/copyutil.py pylib/cqlshlib/test/test_client_routes.py`
- `python3 -m pytest pylib/cqlshlib/test/test_client_routes.py pylib/cqlshlib/test/test_compression.py pylib/cqlshlib/test/test_copyutil.py -q`
- `python3 bin/cqlsh.py --help`