### PR TITLE
Fix client routes follow-ups

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -2020,6 +2020,8 @@ class Shell(cmd.Cmd):
                          connect_timeout=self.conn.connect_timeout,
                          is_subshell=True,
                          auth_provider=self.auth_provider,
+                         client_routes_config=self.client_routes_config,
+                         contact_points=self.contact_points,
                          )
         # duplicate coverage related settings in subshell
         if self.coverage:

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -475,6 +475,7 @@ class Shell(cmd.Cmd):
                  no_compression=False,
                  client_routes_config=None,
                  contact_points=None,
+                 profiles=None,
                  ):
         cmd.Cmd.__init__(self, completekey=completekey)
         self.hostname = hostname
@@ -497,18 +498,19 @@ class Shell(cmd.Cmd):
         self.tracing_enabled = tracing_enabled
         self.page_size = self.default_page_size
         self.expand_enabled = expand_enabled
+        # LOGIN builds a new Cluster from these, so they have to be set even for a subshell
+        # that borrows its parent's connection and never builds one here
+        self.profiles = profiles if profiles is not None else {
+            EXEC_PROFILE_DEFAULT: ExecutionProfile(consistency_level=cassandra.ConsistencyLevel.ONE,
+                                                   request_timeout=request_timeout,
+                                                   row_factory=ordered_dict_factory)
+        }
         if use_conn:
             self.conn = use_conn
         else:
             kwargs = {}
             if protocol_version is not None:
                 kwargs['protocol_version'] = protocol_version
-
-            self.profiles = {
-                EXEC_PROFILE_DEFAULT: ExecutionProfile(consistency_level=cassandra.ConsistencyLevel.ONE,
-                                                       request_timeout=request_timeout,
-                                                       row_factory=ordered_dict_factory)
-            }
 
             if self.is_unix_socket(self.hostname):
                 self.contact_points = (UnixSocketEndPoint(self.hostname),)
@@ -2020,8 +2022,10 @@ class Shell(cmd.Cmd):
                          connect_timeout=self.conn.connect_timeout,
                          is_subshell=True,
                          auth_provider=self.auth_provider,
+                         no_compression=self.no_compression,
                          client_routes_config=self.client_routes_config,
                          contact_points=self.contact_points,
+                         profiles=self.profiles,
                          )
         # duplicate coverage related settings in subshell
         if self.coverage:

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -467,19 +467,38 @@ class CopyTask(object):
     def get_host(shell):
         """
         Return the host COPY uses to determine local datacenter and fallback address.
+
+        With client routes the control connection is opened against a proxy endpoint that
+        never matches a host in the driver metadata, so get_control_connection_host() keeps
+        returning None for the whole session and we have to pick a host ourselves. That pick
+        decides local_dc, which decides which replicas COPY talks to, so prefer a host we
+        know we are connected to, keep the choice deterministic instead of depending on
+        metadata iteration order, and say so when the cluster spans several datacenters.
         """
         host = shell.conn.get_control_connection_host()
         if host is not None or getattr(shell, 'client_routes_config', None) is None:
             return host
 
-        hosts = shell.conn.metadata.all_hosts()
+        hosts = sorted(shell.conn.metadata.all_hosts(),
+                       key=lambda h: (str(h.datacenter), str(h.address)))
         if not hosts:
+            shell.printerr('Unable to pick a host for COPY: the cluster metadata has no hosts')
             return None
 
-        for metadata_host in hosts:
-            if metadata_host.is_up is not False:
-                return metadata_host
-        return hosts[0]
+        candidates = [h for h in hosts if h.is_up is not False] or hosts
+        # a contact point that is also a known host is the closest we can get to the host
+        # the control connection is actually talking to
+        contact_points = {str(getattr(cp, 'address', cp))
+                          for cp in (getattr(shell, 'contact_points', None) or ())}
+        chosen = next((h for h in candidates if str(h.address) in contact_points), candidates[0])
+
+        datacenters = sorted({str(h.datacenter) for h in candidates})
+        if len(datacenters) > 1:
+            shell.printerr('Warning: the control connection host is unknown with client routes, '
+                           'so COPY picked %s in datacenter %s out of %s. Data owned only by '
+                           'replicas in the other datacenters may be unreachable.'
+                           % (chosen.address, chosen.datacenter, ', '.join(datacenters)))
+        return chosen
 
     def close(self):
         self.stop_processes()

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -257,7 +257,7 @@ class CopyTask(object):
         self.ks = ks
         self.table = table
         self.table_meta = self.shell.get_table_meta(self.ks, self.table)
-        self.host = shell.conn.get_control_connection_host()
+        self.host = self.get_host(shell)
         self.fname = safe_normpath(fname)
         self.protocol_version = protocol_version
         self.config_file = config_file
@@ -462,6 +462,24 @@ class CopyTask(object):
         to specify all columns except a few.
         """
         return shell.get_column_names(ks, table) if not columns else columns
+
+    @staticmethod
+    def get_host(shell):
+        """
+        Return the host COPY uses to determine local datacenter and fallback address.
+        """
+        host = shell.conn.get_control_connection_host()
+        if host is not None or getattr(shell, 'client_routes_config', None) is None:
+            return host
+
+        hosts = shell.conn.metadata.all_hosts()
+        if not hosts:
+            return None
+
+        for metadata_host in hosts:
+            if metadata_host.is_up is not False:
+                return metadata_host
+        return hosts[0]
 
     def close(self):
         self.stop_processes()
@@ -1478,6 +1496,13 @@ class ChildProcess(mp.Process):
         self.inmsg.close()
         self.outmsg.close()
 
+    def get_ssl_settings_host(self, default_host):
+        if self.client_routes_config is None or not self.contact_points:
+            return default_host
+
+        contact_point = self.contact_points[0]
+        return str(getattr(contact_point, 'address', contact_point))
+
     def start_coverage(self):
         import coverage
         self.coverage_collection = coverage.Coverage(config_file=self.coveragerc_path)
@@ -1721,7 +1746,7 @@ class ExportProcess(ChildProcess):
             cql_version=self.cql_version,
             protocol_version=self.protocol_version,
             auth_provider=self.auth_provider,
-            ssl_context=ssl_settings(host, self.config_file) if self.ssl else None,
+            ssl_context=ssl_settings(self.get_ssl_settings_host(host), self.config_file) if self.ssl else None,
             load_balancing_policy=WhiteListRoundRobinPolicy([host]),
             default_retry_policy=ExpBackoffRetryPolicy(self),
             compression=None,
@@ -2402,7 +2427,8 @@ class ImportProcess(ChildProcess):
                 protocol_version=self.protocol_version,
                 auth_provider=self.auth_provider,
                 load_balancing_policy=FastTokenAwarePolicy(self),
-                ssl_context=ssl_settings(self.hostname, self.config_file) if self.ssl else None,
+                ssl_context=ssl_settings(self.get_ssl_settings_host(self.hostname),
+                                         self.config_file) if self.ssl else None,
                 default_retry_policy=FallthroughRetryPolicy(),  # we throw on timeouts and retry in the error callback
                 compression=None,
                 control_connection_timeout=self.connect_timeout,

--- a/pylib/cqlshlib/test/test_client_routes.py
+++ b/pylib/cqlshlib/test/test_client_routes.py
@@ -157,3 +157,93 @@ def test_shell_passes_client_routes_config_to_cluster(cqlsh_module):
     assert call_kwargs['client_routes_config'] is client_routes_config
     profile = call_kwargs['execution_profiles'][cqlsh_module.EXEC_PROFILE_DEFAULT]
     assert isinstance(profile.load_balancing_policy, cqlsh_module.RoundRobinPolicy)
+
+
+def test_login_reconnect_preserves_client_routes(cqlsh_module):
+    client_routes_config = object()
+    contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+    profile = cqlsh_module.ExecutionProfile(load_balancing_policy=cqlsh_module.RoundRobinPolicy())
+
+    shell = MagicMock()
+    shell.contact_points = contact_points
+    shell.port = 9042
+    shell.conn.cql_version = '3.4.5'
+    shell.conn.protocol_version = 4
+    shell.conn.connect_timeout = 5
+    shell.conn.ssl_context = 'ssl-context'
+    shell.conn.ssl_options = {'server_hostname': 'proxy-a.example.com'}
+    shell.client_routes_config = client_routes_config
+    shell.no_compression = False
+    shell.profiles = {cqlsh_module.EXEC_PROFILE_DEFAULT: profile}
+    shell.current_keyspace = 'testks'
+    shell.session.max_trace_wait = 10
+
+    parsed = MagicMock()
+    parsed.get_binding.side_effect = lambda name: {
+        'username': 'alice',
+        'password': "'secret'",
+    }[name]
+
+    with patch.object(cqlsh_module, 'Cluster') as mock_cluster:
+        session = MagicMock()
+        mock_cluster.return_value.connect.return_value = session
+
+        cqlsh_module.Shell.do_login(shell, parsed)
+
+    call_kwargs = mock_cluster.call_args[1]
+    assert call_kwargs['contact_points'] == contact_points
+    assert call_kwargs['client_routes_config'] is client_routes_config
+    assert call_kwargs['execution_profiles'] is shell.profiles
+    profile = call_kwargs['execution_profiles'][cqlsh_module.EXEC_PROFILE_DEFAULT]
+    assert isinstance(profile.load_balancing_policy, cqlsh_module.RoundRobinPolicy)
+    mock_cluster.return_value.connect.assert_called_once_with('testks')
+    assert shell.conn is mock_cluster.return_value
+    assert shell.session is session
+
+
+def test_source_subshell_preserves_client_routes(cqlsh_module, tmp_path):
+    client_routes_config = object()
+    contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+    source_file = tmp_path / 'source.cql'
+    source_file.write_text('COPY test.tbl TO STDOUT;\n')
+
+    parent_shell = MagicMock()
+    parent_shell.hostname = 'proxy-a.example.com'
+    parent_shell.port = 9042
+    parent_shell.color = False
+    parent_shell.username = None
+    parent_shell.encoding = 'utf-8'
+    parent_shell.conn.connect_timeout = 5
+    parent_shell.session.default_timeout = 10
+    parent_shell.cql_version = '3.4.5'
+    parent_shell.current_keyspace = 'testks'
+    parent_shell.tracing_enabled = False
+    parent_shell.display_nanotime_format = cqlsh_module.DEFAULT_NANOTIME_FORMAT
+    parent_shell.display_timestamp_format = cqlsh_module.DEFAULT_TIMESTAMP_FORMAT
+    parent_shell.display_date_format = cqlsh_module.DEFAULT_DATE_FORMAT
+    parent_shell.display_float_precision = cqlsh_module.DEFAULT_FLOAT_PRECISION
+    parent_shell.display_double_precision = cqlsh_module.DEFAULT_DOUBLE_PRECISION
+    parent_shell.display_timezone = None
+    parent_shell.max_trace_wait = cqlsh_module.DEFAULT_MAX_TRACE_WAIT
+    parent_shell.ssl = False
+    parent_shell.auth_provider = None
+    parent_shell.client_routes_config = client_routes_config
+    parent_shell.contact_points = contact_points
+    parent_shell.coverage = False
+    parent_shell.cql_unprotect_value.return_value = str(source_file)
+
+    parsed = MagicMock()
+    parsed.get_binding.return_value = str(source_file)
+
+    original_shell = cqlsh_module.Shell
+    with patch.object(cqlsh_module, 'Shell') as mock_shell:
+        subshell = MagicMock()
+        mock_shell.return_value = subshell
+
+        original_shell.do_source(parent_shell, parsed)
+
+    call_kwargs = mock_shell.call_args[1]
+    assert call_kwargs['use_conn'] is parent_shell.conn
+    assert call_kwargs['client_routes_config'] is client_routes_config
+    assert call_kwargs['contact_points'] == contact_points
+    subshell.cmdloop.assert_called_once_with()

--- a/pylib/cqlshlib/test/test_client_routes.py
+++ b/pylib/cqlshlib/test/test_client_routes.py
@@ -204,6 +204,8 @@ def test_login_reconnect_preserves_client_routes(cqlsh_module):
 def test_source_subshell_preserves_client_routes(cqlsh_module, tmp_path):
     client_routes_config = object()
     contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+    profiles = {cqlsh_module.EXEC_PROFILE_DEFAULT: cqlsh_module.ExecutionProfile(
+        load_balancing_policy=cqlsh_module.RoundRobinPolicy())}
     source_file = tmp_path / 'source.cql'
     source_file.write_text('COPY test.tbl TO STDOUT;\n')
 
@@ -229,6 +231,8 @@ def test_source_subshell_preserves_client_routes(cqlsh_module, tmp_path):
     parent_shell.auth_provider = None
     parent_shell.client_routes_config = client_routes_config
     parent_shell.contact_points = contact_points
+    parent_shell.profiles = profiles
+    parent_shell.no_compression = True
     parent_shell.coverage = False
     parent_shell.cql_unprotect_value.return_value = str(source_file)
 
@@ -246,4 +250,85 @@ def test_source_subshell_preserves_client_routes(cqlsh_module, tmp_path):
     assert call_kwargs['use_conn'] is parent_shell.conn
     assert call_kwargs['client_routes_config'] is client_routes_config
     assert call_kwargs['contact_points'] == contact_points
+    # the subshell never builds a Cluster itself, but LOGIN inside the sourced file does
+    assert call_kwargs['profiles'] is profiles
+    assert call_kwargs['no_compression'] is True
     subshell.cmdloop.assert_called_once_with()
+
+
+def fake_parent_connection():
+    """
+    A parent Shell connection that a subshell can borrow, answering the version probes
+    Shell.__init__ makes.
+    """
+    conn = MagicMock()
+    session = MagicMock()
+    conn.connect.return_value = session
+    conn.protocol_version = 4
+    conn.cql_version = '3.4.5'
+    conn.connect_timeout = 5
+    conn.metadata.keyspaces = []
+
+    def execute_side_effect(query):
+        if 'system.local' in query:
+            return [{'cql_version': '3.4.5', 'release_version': '4.0.0'}]
+        if 'system.versions' in query:
+            return [{'version': '5.0.0'}]
+        return []
+
+    session.execute.side_effect = execute_side_effect
+    return conn
+
+
+def test_subshell_login_reconnects_with_the_parent_connection_settings(cqlsh_module):
+    """
+    A subshell borrows its parent's connection and never builds a Cluster in __init__, but
+    LOGIN builds one, so the subshell still needs the parent's execution profiles (client
+    routes replace the default whitelist policy with a RoundRobinPolicy) and the parent's
+    compression setting.
+    """
+    client_routes_config = object()
+    contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+    profiles = {cqlsh_module.EXEC_PROFILE_DEFAULT: cqlsh_module.ExecutionProfile(
+        load_balancing_policy=cqlsh_module.RoundRobinPolicy())}
+
+    subshell = cqlsh_module.Shell('proxy-a.example.com', 9042,
+                                  tty=False,
+                                  encoding='utf-8',
+                                  use_conn=fake_parent_connection(),
+                                  is_subshell=True,
+                                  no_compression=True,
+                                  client_routes_config=client_routes_config,
+                                  contact_points=contact_points,
+                                  profiles=profiles)
+
+    assert subshell.profiles is profiles
+
+    parsed = MagicMock()
+    parsed.get_binding.side_effect = lambda name: {
+        'username': 'alice',
+        'password': "'secret'",
+    }[name]
+
+    with patch.object(cqlsh_module, 'Cluster') as mock_cluster:
+        mock_cluster.return_value.connect.return_value = MagicMock()
+
+        subshell.do_login(parsed)
+
+    call_kwargs = mock_cluster.call_args[1]
+    assert call_kwargs['execution_profiles'] is profiles
+    assert call_kwargs['client_routes_config'] is client_routes_config
+    assert call_kwargs['contact_points'] == contact_points
+    assert call_kwargs['compression'] is False
+    profile = call_kwargs['execution_profiles'][cqlsh_module.EXEC_PROFILE_DEFAULT]
+    assert isinstance(profile.load_balancing_policy, cqlsh_module.RoundRobinPolicy)
+
+
+def test_shell_builds_default_profiles_when_none_are_passed(cqlsh_module):
+    subshell = cqlsh_module.Shell('proxy-a.example.com', 9042,
+                                  tty=False,
+                                  encoding='utf-8',
+                                  use_conn=fake_parent_connection(),
+                                  is_subshell=True)
+
+    assert cqlsh_module.EXEC_PROFILE_DEFAULT in subshell.profiles

--- a/pylib/cqlshlib/test/test_copyutil.py
+++ b/pylib/cqlshlib/test/test_copyutil.py
@@ -21,11 +21,13 @@ import csv
 import os
 import tempfile
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from cassandra.metadata import MIN_LONG, Murmur3Token
+from cassandra.policies import WhiteListRoundRobinPolicy
 
-from cqlshlib.copyutil import ExportTask, ImportTask, ImportTaskError
+from cqlshlib.copyutil import (ExportProcess, ExportTask, FastTokenAwarePolicy, ImportProcess, ImportTask,
+                               ImportTaskError)
 
 
 Default = object()
@@ -48,6 +50,7 @@ class CopyTaskTest(unittest.TestCase):
             host = Mock()
             host.address = ip
             host.datacenter = 'dc1'
+            host.is_up = True
             self.hosts.append(host)
 
     def mock_shell(self):
@@ -59,6 +62,7 @@ class CopyTaskTest(unittest.TestCase):
         shell.conn.get_control_connection_host.return_value = self.hosts[0]
         shell.conn.connect_timeout = 5
         shell.conn.cql_version = '3.4.5'
+        shell.conn.metadata.all_hosts.return_value = self.hosts
         shell.get_column_names.return_value = self.columns
         shell.debug = False
         shell.coverage = False
@@ -66,6 +70,8 @@ class CopyTaskTest(unittest.TestCase):
         shell.port = 9042
         shell.ssl = None
         shell.auth_provider = None
+        shell.client_routes_config = None
+        shell.contact_points = (self.hosts[0].address,)
         shell.consistency_level = 'ONE'
         shell.display_timestamp_format = 'DEFAULT_TIMESTAMP_FORMAT'
         shell.display_date_format = 'DEFAULT_DATE_FORMAT'
@@ -160,8 +166,92 @@ class TestExportTask(CopyTaskTest):
         self.assertEqual(params['contact_points'], shell.contact_points)
         export_task.close()
 
+    def test_export_process_uses_client_routes_when_connecting_worker(self):
+        shell = self.mock_shell()
+        shell.client_routes_config = object()
+        shell.contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+        shell.ssl = True
+        ssl_context = object()
+        export_task = ExportTask(shell, self.ks, self.table, self.columns,
+                                 self.fname, {}, self.protocol_version, self.config_file)
+        export_process = ExportProcess(export_task.update_params(export_task.make_params(), 0))
+
+        with patch('cqlshlib.copyutil.ssl_settings', return_value=ssl_context) as mock_ssl_settings, \
+                patch('cqlshlib.copyutil.Cluster') as mock_cluster:
+            mock_cluster.return_value.connect.return_value = Mock()
+
+            export_process.connect('10.0.0.2')
+
+        call_kwargs = mock_cluster.call_args[1]
+        self.assertEqual(call_kwargs['contact_points'], shell.contact_points)
+        self.assertIs(call_kwargs['client_routes_config'], shell.client_routes_config)
+        self.assertIsInstance(call_kwargs['load_balancing_policy'], WhiteListRoundRobinPolicy)
+        self.assertIs(call_kwargs['ssl_context'], ssl_context)
+        mock_ssl_settings.assert_called_once_with('proxy-a.example.com', self.config_file)
+        export_task.close()
+
+    def test_get_ranges_uses_metadata_host_when_client_routes_control_host_missing(self):
+        shell = self.mock_shell()
+        shell.conn.get_control_connection_host.return_value = None
+        shell.client_routes_config = object()
+        shell.contact_points = ('proxy-a.example.com',)
+        shell.conn.metadata.partitioner = 'Murmur3Partitioner'
+        shell.conn.metadata.token_map = None
+        shell.conn.metadata.all_hosts.return_value = [self.hosts[1]]
+
+        export_task = ExportTask(shell, self.ks, self.table, self.columns,
+                                 self.fname, {}, self.protocol_version, self.config_file)
+
+        self.assertEqual(export_task.get_ranges(), {
+            (None, None): {'hosts': ('10.0.0.2',), 'attempts': 0, 'rows': 0, 'workerno': -1}
+        })
+        export_task.close()
+
 
 class TestImportTask(CopyTaskTest):
+    def test_make_params_uses_metadata_host_when_client_routes_control_host_missing(self):
+        shell = self.mock_shell()
+        shell.conn.get_control_connection_host.return_value = None
+        shell.client_routes_config = object()
+        shell.contact_points = ('proxy-a.example.com',)
+        shell.conn.metadata.all_hosts.return_value = [self.hosts[2]]
+
+        import_task = ImportTask(shell, self.ks, self.table, self.columns,
+                                 self.fname, {}, self.protocol_version, self.config_file)
+        params = import_task.make_params()
+
+        self.assertEqual(params['hostname'], '10.0.0.3')
+        self.assertEqual(params['local_dc'], 'dc1')
+        self.assertIs(params['client_routes_config'], shell.client_routes_config)
+        self.assertEqual(params['contact_points'], shell.contact_points)
+        import_task.close()
+
+    def test_import_process_uses_client_routes_when_connecting_worker(self):
+        shell = self.mock_shell()
+        shell.client_routes_config = object()
+        shell.contact_points = ('proxy-a.example.com', 'proxy-b.example.com')
+        shell.ssl = True
+        ssl_context = object()
+        import_task = ImportTask(shell, self.ks, self.table, self.columns,
+                                 self.fname, {}, self.protocol_version, self.config_file)
+        import_process = ImportProcess(import_task.update_params(import_task.make_params(), 0))
+
+        with patch('cqlshlib.copyutil.ssl_settings', return_value=ssl_context) as mock_ssl_settings, \
+                patch('cqlshlib.copyutil.Cluster') as mock_cluster:
+            session = Mock()
+            mock_cluster.return_value.connect.return_value = session
+
+            self.assertIs(import_process.session, session)
+
+        call_kwargs = mock_cluster.call_args[1]
+        self.assertEqual(call_kwargs['contact_points'], shell.contact_points)
+        self.assertIs(call_kwargs['client_routes_config'], shell.client_routes_config)
+        self.assertIsInstance(call_kwargs['load_balancing_policy'], FastTokenAwarePolicy)
+        self.assertIs(call_kwargs['ssl_context'], ssl_context)
+        mock_ssl_settings.assert_called_once_with('proxy-a.example.com', self.config_file)
+        mock_cluster.return_value.connect.assert_called_once_with(self.ks)
+        import_task.close()
+
     def test_validate_columns(self):
         shell = self.mock_shell()
         shell.conn.metadata.partitioner = 'Murmur3Partitioner'

--- a/pylib/cqlshlib/test/test_copyutil.py
+++ b/pylib/cqlshlib/test/test_copyutil.py
@@ -26,7 +26,7 @@ from unittest.mock import Mock, patch
 from cassandra.metadata import MIN_LONG, Murmur3Token
 from cassandra.policies import WhiteListRoundRobinPolicy
 
-from cqlshlib.copyutil import (ExportProcess, ExportTask, FastTokenAwarePolicy, ImportProcess, ImportTask,
+from cqlshlib.copyutil import (CopyTask, ExportProcess, ExportTask, FastTokenAwarePolicy, ImportProcess, ImportTask,
                                ImportTaskError)
 
 
@@ -86,6 +86,87 @@ class CopyTaskTest(unittest.TestCase):
         shell.get_table_meta.return_value = table_meta
 
         return shell
+
+
+class TestGetHost(CopyTaskTest):
+    """
+    CopyTask.get_host picks the host whose datacenter becomes local_dc, which decides which
+    replicas COPY talks to, so the pick must not depend on driver metadata iteration order.
+    """
+
+    def mock_shell_without_control_host(self):
+        shell = self.mock_shell()
+        shell.conn.get_control_connection_host.return_value = None
+        shell.client_routes_config = object()
+        shell.contact_points = ('proxy-a.example.com',)
+        return shell
+
+    def test_returns_control_connection_host_when_available(self):
+        shell = self.mock_shell()
+        self.assertIs(CopyTask.get_host(shell), self.hosts[0])
+        shell.conn.metadata.all_hosts.assert_not_called()
+
+    def test_returns_none_without_client_routes(self):
+        shell = self.mock_shell()
+        shell.conn.get_control_connection_host.return_value = None
+
+        self.assertIsNone(CopyTask.get_host(shell))
+        shell.conn.metadata.all_hosts.assert_not_called()
+
+    def test_is_deterministic_regardless_of_metadata_order(self):
+        shell = self.mock_shell_without_control_host()
+
+        shell.conn.metadata.all_hosts.return_value = list(self.hosts)
+        first = CopyTask.get_host(shell)
+        shell.conn.metadata.all_hosts.return_value = list(reversed(self.hosts))
+        second = CopyTask.get_host(shell)
+
+        self.assertIs(first, second)
+        self.assertEqual(first.address, '10.0.0.1')
+
+    def test_prefers_a_host_that_is_also_a_contact_point(self):
+        shell = self.mock_shell_without_control_host()
+        shell.contact_points = ('proxy-a.example.com', self.hosts[2].address)
+
+        self.assertIs(CopyTask.get_host(shell), self.hosts[2])
+
+    def test_skips_down_hosts(self):
+        shell = self.mock_shell_without_control_host()
+        self.hosts[0].is_up = False
+        self.hosts[1].is_up = False
+
+        self.assertIs(CopyTask.get_host(shell), self.hosts[2])
+
+    def test_falls_back_to_a_down_host_when_all_are_down(self):
+        shell = self.mock_shell_without_control_host()
+        for host in self.hosts:
+            host.is_up = False
+
+        self.assertIs(CopyTask.get_host(shell), self.hosts[0])
+
+    def test_warns_when_hosts_span_datacenters(self):
+        shell = self.mock_shell_without_control_host()
+        self.hosts[2].datacenter = 'dc2'
+        self.hosts[3].datacenter = 'dc2'
+
+        self.assertIs(CopyTask.get_host(shell), self.hosts[0])
+        shell.printerr.assert_called_once()
+        message = shell.printerr.call_args[0][0]
+        self.assertIn('10.0.0.1', message)
+        self.assertIn('dc1, dc2', message)
+
+    def test_does_not_warn_for_a_single_datacenter(self):
+        shell = self.mock_shell_without_control_host()
+
+        self.assertIs(CopyTask.get_host(shell), self.hosts[0])
+        shell.printerr.assert_not_called()
+
+    def test_reports_empty_cluster_metadata(self):
+        shell = self.mock_shell_without_control_host()
+        shell.conn.metadata.all_hosts.return_value = []
+
+        self.assertIsNone(CopyTask.get_host(shell))
+        shell.printerr.assert_called_once()
 
 
 class TestExportTask(CopyTaskTest):


### PR DESCRIPTION
Follow-up to #204.

Summary:
- preserve client routes when SOURCE creates a subshell
- preserve a metadata host fallback for COPY when client routes leave the control host unavailable
- use routed contact points for COPY worker SSL settings with client routes
- add worker-level COPY tests for routed Cluster kwargs and load-balancing policies
- add LOGIN reconnect coverage for client routes

Upstream status:
- #204 was squash-merged as 0c1af02 and current origin/master contains the same client-routes file changes as local commit 56809c9, so this PR only carries follow-up fixes.

Tests:
- python3 -m pytest pylib/cqlshlib/test/test_copyutil.py
- python3 -m pytest pylib/cqlshlib/test/test_client_routes.py