### PR TITLE
saferscanner: stop importing the removed sre_constants module

### DIFF
--- a/pylib/cqlshlib/saferscanner.py
+++ b/pylib/cqlshlib/saferscanner.py
@@ -19,15 +19,22 @@
 # regex in-pattern flags. Any of those can break correct operation of Scanner.
 
 import re
-from sre_constants import BRANCH, SUBPATTERN, GROUPREF, GROUPREF_IGNORE, GROUPREF_EXISTS
 from sys import version_info
 
 try:
     sre_parse = re._parser
     sre_compile = re._compiler
+    sre_constants = re._constants
 except AttributeError:
     sre_parse = re.sre_parse
     sre_compile = re.sre_compile
+    import sre_constants
+
+BRANCH = sre_constants.BRANCH
+SUBPATTERN = sre_constants.SUBPATTERN
+GROUPREF = sre_constants.GROUPREF
+GROUPREF_IGNORE = sre_constants.GROUPREF_IGNORE
+GROUPREF_EXISTS = sre_constants.GROUPREF_EXISTS
 
 
 class SaferScannerBase(re.Scanner):


### PR DESCRIPTION
Python 3.15 removes the deprecated sre_constants shim, so `from sre_constants import BRANCH, ...` makes cqlsh fail to start at import time under a rawhide-based (future) toolchain:

    ModuleNotFoundError: No module named 'sre_constants'

The module already resolves sre_parse/sre_compile via re._parser and re._compiler with a fallback for older interpreters; extend the same pattern to the constants, taking them from re._constants when it exists and from sre_constants otherwise. This keeps working on the current toolchain's Python 3.14, where sre_constants is present but deprecated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Ref https://scylladb.atlassian.net/browse/SCYLLADB-4242