### PR TITLE
docker: move base image off EOL Debian bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye AS compile-image
+FROM python:3.13-slim-trixie AS compile-image
 
 WORKDIR /usr/src/app
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install --no-install-recommends git gcc libc6-dev
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --upgrade pip==26.1 setuptools==82.0.1 wheel==0.4
 RUN pip install --user .
 
 
-FROM python:3.13-slim-bullseye AS build-image
+FROM python:3.13-slim-trixie AS build-image
 
 # Upgrade packages to the latest, pip as well.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The `docker` job has been failing on master ([run 34035481542](https://github.com/scylladb/scylla-cqlsh/actions/runs/34035481542/job/101492642601)) with 404s from `deb.debian.org`:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc-dev-bin_2.31-13%2bdeb11u14_amd64.deb  404  Not Found
E: Failed to fetch .../libperl5.32_5.32.1-4%2bdeb11u5_amd64.deb  404  Not Found
E: Failed to fetch .../linux-libc-dev_5.10.262-1_amd64.deb  404  Not Found
```

Debian 11 (bullseye) is past end of life and its security pool is being archived, so package versions still listed in the freshly fetched indexes are no longer downloadable — `apt-get update && apt-get install` in a single layer doesn't help. `python:3.13-slim-bullseye` is also no longer rebuilt upstream (last push Aug 2025), unlike `-bookworm` / `-trixie` which were rebuilt this month.

Both stages now use `python:3.13-slim-trixie` (Debian 13, current stable).

Verified locally with buildx: `linux/amd64` and `linux/arm64` (via QEMU) both build, and `cqlsh --version` runs in the resulting image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)